### PR TITLE
Update uiSchema

### DIFF
--- a/.config/configstore/update-notifier-nodemon.json
+++ b/.config/configstore/update-notifier-nodemon.json
@@ -1,4 +1,4 @@
 {
     "optOut": false,
-    "lastUpdateCheck": 1566381835417
+    "lastUpdateCheck": 1566813830208
 }

--- a/.config/configstore/update-notifier-npm.json
+++ b/.config/configstore/update-notifier-npm.json
@@ -1,10 +1,4 @@
 {
     "optOut": false,
-    "lastUpdateCheck": 1566813827557,
-    "update": {
-        "latest": "6.11.2",
-        "current": "6.4.1",
-        "type": "minor",
-        "name": "npm"
-    }
+    "lastUpdateCheck": 1566813827557
 }

--- a/.config/configstore/update-notifier-npm.json
+++ b/.config/configstore/update-notifier-npm.json
@@ -1,4 +1,10 @@
 {
     "optOut": false,
-    "lastUpdateCheck": 1566381835774
+    "lastUpdateCheck": 1566813827557,
+    "update": {
+        "latest": "6.11.2",
+        "current": "6.4.1",
+        "type": "minor",
+        "name": "npm"
+    }
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,4 +27,3 @@ const config = {
 /*! m0-start */
 module.exports = config;
 /*! m0-end */
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -6926,8 +6926,8 @@
             }
         },
         "q-transformer": {
-            "version": "git+https://github.com/CriminalInjuriesCompensationAuthority/q-transformer.git#6199ae40d071303df90c17a1d90ff10a76ec1d91",
-            "from": "git+https://github.com/CriminalInjuriesCompensationAuthority/q-transformer.git",
+            "version": "git+https://github.com/CriminalInjuriesCompensationAuthority/q-transformer.git#070a93ae222f49c5e6329794cf31a2b2d1b65a41",
+            "from": "git+https://github.com/CriminalInjuriesCompensationAuthority/q-transformer.git#BP03-autocomplete",
             "requires": {
                 "lodash.merge": "^4.6.1",
                 "moment": "^2.24.0"

--- a/questionnaire/form-helper.js
+++ b/questionnaire/form-helper.js
@@ -19,16 +19,33 @@ nunjucks.configure(
     }
 );
 
+function getButtonText(sectionId) {
+    return sectionId in uiSchema &&
+        uiSchema[sectionId].options &&
+        uiSchema[sectionId].options.buttonText
+        ? uiSchema[sectionId].options.buttonText
+        : 'Continue';
+}
+
+function checkIsSummary(sectionId) {
+    return sectionId in uiSchema &&
+        uiSchema[sectionId].options &&
+        uiSchema[sectionId].options.isSummary
+        ? uiSchema[sectionId].options.isSummary
+        : false;
+}
+
 function renderSection(
     transformation,
     isFinal,
     backTarget,
-    isSummary,
+    sectionId,
     variables = {},
     showBackLink = true
 ) {
-    const buttonTitle = isSummary ? 'Agree and Submit' : 'Continue';
     const showButton = !isFinal;
+    const isSummary = checkIsSummary(sectionId);
+    const buttonTitle = getButtonText(sectionId);
     return nunjucks.renderString(
         `
             {% extends "page.njk" %}
@@ -170,7 +187,6 @@ function getSectionHtml(sectionData, allAnswers) {
     } else {
         answers = processPreviousAnswers(allAnswers.body.data);
     }
-    const summary = display.summary === sectionId;
     const backLink = `/apply/previous/${removeSectionIdPrefix(sectionId)}`;
     const transformation = qTransformer.transform({
         schemaKey: sectionId,
@@ -178,7 +194,7 @@ function getSectionHtml(sectionData, allAnswers) {
         uiSchema,
         data: answers
     });
-    return renderSection(transformation, display.final, backLink, summary);
+    return renderSection(transformation, display.final, backLink, sectionId);
 }
 
 function processErrors(errors) {
@@ -206,7 +222,6 @@ function getSectionHtmlWithErrors(sectionData, body = {}, sectionId) {
     const {schema} = sectionData.meta;
     const errorObject = processErrors(sectionData.errors);
     const display = {final: false}; // sectionData.meta; // ToDo: Add these to meta for POST answers
-    const summary = false; // display.summary === sectionId;
     const backLink = `/apply/previous/${removeSectionIdPrefix(sectionId)}`;
     const transformation = qTransformer.transform({
         schemaKey: sectionId,
@@ -215,7 +230,7 @@ function getSectionHtmlWithErrors(sectionData, body = {}, sectionId) {
         data: body,
         schemaErrors: errorObject
     });
-    return renderSection(transformation, display.final, backLink, summary);
+    return renderSection(transformation, display.final, backLink, sectionId);
 }
 
 function getNextSection(nextSectionId, requestedNextSectionId = undefined) {
@@ -232,6 +247,8 @@ function addPrefix(section) {
 }
 
 module.exports = {
+    getButtonText,
+    checkIsSummary,
     renderSection,
     removeSectionIdPrefix,
     inUiSchema,

--- a/questionnaire/form-helper.js
+++ b/questionnaire/form-helper.js
@@ -218,16 +218,17 @@ function processErrors(errors) {
     return errorObject;
 }
 
-function getSectionHtmlWithErrors(sectionData, body = {}, sectionId) {
+function getSectionHtmlWithErrors(sectionData, sectionId) {
     const {schema} = sectionData.meta;
     const errorObject = processErrors(sectionData.errors);
     const display = {final: false}; // sectionData.meta; // ToDo: Add these to meta for POST answers
     const backLink = `/apply/previous/${removeSectionIdPrefix(sectionId)}`;
+    const {answers} = sectionData.meta;
     const transformation = qTransformer.transform({
         schemaKey: sectionId,
         schema,
         uiSchema,
-        data: body,
+        data: answers,
         schemaErrors: errorObject
     });
     return renderSection(transformation, display.final, backLink, sectionId);

--- a/questionnaire/questionnaireUISchema.js
+++ b/questionnaire/questionnaireUISchema.js
@@ -160,64 +160,71 @@ module.exports = {
     },
     'p--check-your-answers': {
         options: {
-            isSummary: true
-        },
-        summaryStructure: [
-            {
-                title: 'Your details',
-                questions: [
-                    'p-applicant-enter-your-name',
-                    'p-applicant-have-you-been-known-by-any-other-names',
-                    'p-applicant-what-other-names-have-you-used',
-                    'p-applicant-enter-your-date-of-birth',
-                    'p-applicant-enter-your-email-address',
-                    'p-applicant-enter-your-address',
-                    'p-applicant-enter-your-telephone-number',
-                    'p-applicant-british-citizen-or-eu-national',
-                    'p-applicant-are-you-18-or-over',
-                    'p-applicant-who-are-you-applying-for',
-                    'p-applicant-were-you-a-victim-of-sexual-assault-or-abuse',
-                    'p-applicant-select-the-option-that-applies-to-you'
-                ]
-            },
-            {
-                title: 'About the crime',
-                questions: [
-                    'p-applicant-did-the-crime-happen-once-or-over-time',
-                    'p-applicant-when-did-the-crime-happen',
-                    'p-applicant-when-did-the-crime-start',
-                    'p-applicant-when-did-the-crime-stop',
-                    'p-applicant-select-reasons-for-the-delay-in-making-your-application',
-                    'p-applicant-where-did-the-crime-happen',
-                    'p-applicant-where-in-england-did-it-happen',
-                    'p-applicant-where-in-scotland-did-it-happen',
-                    'p-applicant-where-in-wales-did-it-happen',
-                    'p-offender-do-you-know-the-name-of-the-offender',
-                    'p-offender-enter-offenders-name',
-                    'p-offender-describe-contact-with-offender'
-                ]
-            },
-            {
-                title: 'Police report',
-                questions: [
-                    'p--was-the-crime-reported-to-police',
-                    'p--when-was-the-crime-reported-to-police',
-                    'p--whats-the-crime-reference-number',
-                    'p--which-english-police-force-is-investigating-the-crime',
-                    'p--which-police-scotland-division-is-investigating-the-crime',
-                    'p--which-welsh-police-force-is-investigating-the-crime',
-                    'p-applicant-select-reasons-for-the-delay-in-reporting-the-crime-to-police'
-                ]
-            },
-            {
-                title: 'Other compensation',
-                questions: [
-                    'p-applicant-have-you-applied-to-us-before',
-                    'p-applicant-have-you-applied-for-or-received-any-other-compensation',
-                    'p-applicant-other-compensation-details'
-                ]
+            isSummary: true,
+            buttonText: 'Agree and Submit',
+            properties: {
+                'p-check-your-answers': {
+                    options: {
+                        summaryStructure: [
+                            {
+                                title: 'Your details',
+                                questions: [
+                                    'p-applicant-enter-your-name',
+                                    'p-applicant-have-you-been-known-by-any-other-names',
+                                    'p-applicant-what-other-names-have-you-used',
+                                    'p-applicant-enter-your-date-of-birth',
+                                    'p-applicant-enter-your-email-address',
+                                    'p-applicant-enter-your-address',
+                                    'p-applicant-enter-your-telephone-number',
+                                    'p-applicant-british-citizen-or-eu-national',
+                                    'p-applicant-are-you-18-or-over',
+                                    'p-applicant-who-are-you-applying-for',
+                                    'p-applicant-were-you-a-victim-of-sexual-assault-or-abuse',
+                                    'p-applicant-select-the-option-that-applies-to-you'
+                                ]
+                            },
+                            {
+                                title: 'About the crime',
+                                questions: [
+                                    'p-applicant-did-the-crime-happen-once-or-over-time',
+                                    'p-applicant-when-did-the-crime-happen',
+                                    'p-applicant-when-did-the-crime-start',
+                                    'p-applicant-when-did-the-crime-stop',
+                                    'p-applicant-select-reasons-for-the-delay-in-making-your-application',
+                                    'p-applicant-where-did-the-crime-happen',
+                                    'p-applicant-where-in-england-did-it-happen',
+                                    'p-applicant-where-in-scotland-did-it-happen',
+                                    'p-applicant-where-in-wales-did-it-happen',
+                                    'p-offender-do-you-know-the-name-of-the-offender',
+                                    'p-offender-enter-offenders-name',
+                                    'p-offender-describe-contact-with-offender'
+                                ]
+                            },
+                            {
+                                title: 'Police report',
+                                questions: [
+                                    'p--was-the-crime-reported-to-police',
+                                    'p--when-was-the-crime-reported-to-police',
+                                    'p--whats-the-crime-reference-number',
+                                    'p--which-english-police-force-is-investigating-the-crime',
+                                    'p--which-police-scotland-division-is-investigating-the-crime',
+                                    'p--which-welsh-police-force-is-investigating-the-crime',
+                                    'p-applicant-select-reasons-for-the-delay-in-reporting-the-crime-to-police'
+                                ]
+                            },
+                            {
+                                title: 'Other compensation',
+                                questions: [
+                                    'p-applicant-have-you-applied-to-us-before',
+                                    'p-applicant-have-you-applied-for-or-received-any-other-compensation',
+                                    'p-applicant-other-compensation-details'
+                                ]
+                            }
+                        ]
+                    }
+                }
             }
-        ]
+        }
     },
     'p-applicant-enter-your-address': {
         options: {

--- a/questionnaire/questionnaireUISchema.js
+++ b/questionnaire/questionnaireUISchema.js
@@ -266,16 +266,16 @@ module.exports = {
     'p-applicant-select-reasons-for-the-delay-in-making-your-application': {
         options: {
             outputOrder: [
-                'q-applicant-explain-reason-for-delay-application',
-                'q-applicant-select-reasons-for-the-delay-in-making-your-application'
+                'q-applicant-select-reasons-for-the-delay-in-making-your-application',
+                'q-applicant-explain-reason-for-delay-application'
             ]
         }
     },
     'p-applicant-select-reasons-for-the-delay-in-reporting-the-crime-to-police': {
         options: {
             outputOrder: [
-                'q-applicant-explain-reason-for-delay-reporting',
-                'q-applicant-select-reasons-for-the-delay-in-reporting-the-crime-to-police'
+                'q-applicant-select-reasons-for-the-delay-in-reporting-the-crime-to-police',
+                'q-applicant-explain-reason-for-delay-reporting'
             ]
         }
     },
@@ -310,6 +310,11 @@ module.exports = {
                 'q-offender-describe-contact-with-offender',
                 'q-offender-i-have-no-contact-with-offender'
             ]
+        }
+    },
+    'p--confirmation': {
+        options: {
+            showBackButton: false
         }
     }
 };

--- a/questionnaire/routes.js
+++ b/questionnaire/routes.js
@@ -77,7 +77,7 @@ router
                 const nextSection = formHelper.getNextSection(nextSectionId, req.query.next);
                 res.redirect(`${req.baseUrl}/${nextSection}`);
             } else {
-                const html = formHelper.getSectionHtmlWithErrors(response.body, body, sectionId);
+                const html = formHelper.getSectionHtmlWithErrors(response.body, sectionId);
                 res.send(html);
             }
         } catch (err) {

--- a/questionnaire/routes.js
+++ b/questionnaire/routes.js
@@ -74,7 +74,7 @@ router
                 const nextSectionId = formHelper.removeSectionIdPrefix(
                     progressEntry.body.data[0].attributes.sectionId
                 );
-                const nextSection = formHelper.getNextSection(nextSectionId, req.query.redirect);
+                const nextSection = formHelper.getNextSection(nextSectionId, req.query.next);
                 res.redirect(`${req.baseUrl}/${nextSection}`);
             } else {
                 const html = formHelper.getSectionHtmlWithErrors(response.body, body, sectionId);

--- a/test/form-helper.test.js
+++ b/test/form-helper.test.js
@@ -338,7 +338,9 @@ describe('form-helper functions', () => {
                 }
             ];
             const expected = {
-                'q-applicant-were-you-a-victim-of-sexual-assault-or-abuse': true
+                'p-applicant-were-you-a-victim-of-sexual-assault-or-abuse': {
+                    'q-applicant-were-you-a-victim-of-sexual-assault-or-abuse': true
+                }
             };
             const actual = formHelper.processPreviousAnswers(answerObject);
 
@@ -358,8 +360,10 @@ describe('form-helper functions', () => {
                 }
             ];
             const expected = {
-                'question-one': 'answer-one',
-                'question-two': 'answer-two'
+                'p-applicant-were-you-a-victim-of-sexual-assault-or-abuse': {
+                    'question-one': 'answer-one',
+                    'question-two': 'answer-two'
+                }
             };
             const actual = formHelper.processPreviousAnswers(answerObject, {});
 
@@ -392,6 +396,44 @@ describe('form-helper functions', () => {
             const actual = formHelper.inUiSchema(sectionName);
 
             expect(actual).toBeUndefined();
+        });
+    });
+
+    describe('Get button text', () => {
+        it('Should return the button text if specificed in the UISchema', () => {
+            const sectionName = 'p--check-your-answers';
+            const expected = 'Agree and Submit';
+
+            const actual = formHelper.getButtonText(sectionName);
+
+            expect(actual).toMatch(expected);
+        });
+
+        it('Should return the default button text if nothing specific is specificed in the UISchema', () => {
+            const sectionName = 'p-applicant-declaration';
+            const expected = 'Continue';
+
+            const actual = formHelper.getButtonText(sectionName);
+
+            expect(actual).toMatch(expected);
+        });
+    });
+
+    describe('Check is summary', () => {
+        it('Should return true if a section has `isSummary: true` in the UISchema', () => {
+            const sectionName = 'p--check-your-answers';
+
+            const actual = formHelper.checkIsSummary(sectionName);
+
+            expect(actual).toEqual(true);
+        });
+
+        it('Should return false if a section has no `isSummary` value in the UISchema', () => {
+            const sectionName = 'p-applicant-declaration';
+
+            const actual = formHelper.checkIsSummary(sectionName);
+
+            expect(actual).toEqual(false);
         });
     });
 });

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -642,15 +642,20 @@ describe('Data capture service endpoints', () => {
             describe('POST', () => {
                 describe('302', () => {
                     beforeAll(() => {
+                        const sectionIdNoPrefix = 'confirmation';
                         jest.resetModules();
                         jest.doMock('../questionnaire/questionnaire-service', () =>
                             // return a modified factory function, that returns an object with a method, that returns a valid created response
                             jest.fn(() => ({
                                 postSubmission: () => {},
                                 getSubmissionStatus: () => postValidSubmission,
-                                createQuestionnaire: () => createQuestionnaire
+                                createQuestionnaire: () => createQuestionnaire,
+                                getCurrentSection: () => getCurrentSection
                             }))
                         );
+                        jest.doMock('../questionnaire/form-helper', () => ({
+                            removeSectionIdPrefix: () => sectionIdNoPrefix
+                        }));
                         // eslint-disable-next-line global-require
                         app = require('../app');
                     });

--- a/test/test-fixtures/res/get_schema_valid.json
+++ b/test/test-fixtures/res/get_schema_valid.json
@@ -1,25 +1,57 @@
 {
-    "data": [
-        {
-            "type": "section",
-            "id": "p-applicant-british-citizen-or-eu-national",
-            "attributes": {
-                "required": ["q-applicant-british-citizen-or-eu-national"],
-                "errorMessage": {
-                    "required": {
-                        "q-applicant-british-citizen-or-eu-national": "Select yes if you are a British citizen or EU national"
-                    }
+    "body": {
+        "data": [
+            {
+                "type": "progress-entries",
+                "id": "p--when-was-the-crime-reported-to-police",
+                "attributes": {
+                    "sectionId": "p--when-was-the-crime-reported-to-police",
+                    "url": null
                 },
-                "additionalProperties": false,
-                "$schema": "http://json-schema.org/draft-07/schema#",
-                "type": "object",
-                "properties": {
-                    "q-applicant-british-citizen-or-eu-national": {
-                        "type": "boolean",
-                        "title": "Are you a British citizen or EU national?"
+                "relationships": {
+                    "section": {
+                        "data": {
+                            "type": "sections",
+                            "id": "p--when-was-the-crime-reported-to-police"
+                        }
                     }
                 }
             }
+        ],
+        "included": [
+            {
+                "type": "sections",
+                "id": "p--when-was-the-crime-reported-to-police",
+                "attributes": {
+                    "type": "object",
+                    "$schema": "http://json-schema.org/draft-07/schema#",
+                    "required": ["q--when-was-the-crime-reported-to-police"],
+                    "properties": {
+                        "q--when-was-the-crime-reported-to-police": {
+                            "type": "string",
+                            "title": "When was the crime reported to the police?",
+                            "format": "date-time",
+                            "description": "For example, 31 3 2018. You can enter an approximate date.",
+                            "errorMessage": {
+                                "format": "The date the crime was reported to the police must be in the past"
+                            }
+                        }
+                    },
+                    "errorMessage": {
+                        "required": {
+                            "q--when-was-the-crime-reported-to-police": "Enter the date the crime was reported to the police"
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            }
+        ],
+        "links": {
+            "prev": "undefined/api/v1/questionnaires/b826e4e1-b6a0-4a1f-8c8d-7600433beaa0/progress-entries?filter[sectionId]=p--was-the-crime-reported-to-police"
+        },
+        "meta": {
+            "summary": "p--check-your-answers",
+            "confirmation": "p--confirmation"
         }
-    ]
+    }
 }

--- a/test/test-fixtures/res/post_valid_submission.json
+++ b/test/test-fixtures/res/post_valid_submission.json
@@ -1,3 +1,6 @@
 {
-    "status": "IN_PROGRESS"
+    "questionnaireId": "285cb104-0c15-4a9c-9840-cb1007f098fb",
+    "submitted": true,
+    "status": "IN_PROGRESS",
+    "caseReferenceNumber": "11\\111111"
 }


### PR DESCRIPTION
This commit updates the uiSchema to include schanges to the CYA page.

This commit facilitates the use of the "buttonText" key to change
the default button text on a section.

This commit also checks whether a page is a summary page or not
using the uiSchema.

This commit also includes a change to how a page redirects when a
query string is used. The variable is now called 'next'.

Finally, this commit also fixes two broken tests.