### PR TITLE
Fix cascading edit 404

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,5 +1,8 @@
+'use strict';
+
 jest.setTimeout(30000);
 jest.testEnvironment = 'node';
 process.env.DATA_CAPTURE_SERVICE = 'some_token';
 process.env.DCS_JWT = 'A massive string';
 process.env.CW_COOKIE_SECRET = 'Also a huge string';
+process.env.CW_DCS_URL = 'http://docker.for.win.localhost:3100/api/v1';

--- a/package-lock.json
+++ b/package-lock.json
@@ -2290,9 +2290,9 @@
             }
         },
         "eslint-utils": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.0.tgz",
-            "integrity": "sha512-7ehnzPaP5IIEh1r1tkjuIrxqhNkzUJa9z3R92tLJdZIVdWaczEhr3EbhGtsMrVxi1KeR8qA7Off6SWc5WNQqyQ==",
+            "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
+            "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
             "dev": true,
             "requires": {
                 "eslint-visitor-keys": "^1.0.0"
@@ -2805,8 +2805,7 @@
                 },
                 "ansi-regex": {
                     "version": "2.1.1",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -2824,13 +2823,11 @@
                 },
                 "balanced-match": {
                     "version": "1.0.0",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
-                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -2843,18 +2840,15 @@
                 },
                 "code-point-at": {
                     "version": "1.1.0",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -2957,8 +2951,7 @@
                 },
                 "inherits": {
                     "version": "2.0.3",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -2968,7 +2961,6 @@
                 "is-fullwidth-code-point": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -2981,20 +2973,17 @@
                 "minimatch": {
                     "version": "3.0.4",
                     "bundled": true,
-                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
                 },
                 "minimist": {
                     "version": "0.0.8",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "minipass": {
                     "version": "2.3.5",
                     "bundled": true,
-                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
@@ -3011,7 +3000,6 @@
                 "mkdirp": {
                     "version": "0.5.1",
                     "bundled": true,
-                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -3084,8 +3072,7 @@
                 },
                 "number-is-nan": {
                     "version": "1.0.1",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -3095,7 +3082,6 @@
                 "once": {
                     "version": "1.4.0",
                     "bundled": true,
-                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -3171,8 +3157,7 @@
                 },
                 "safe-buffer": {
                     "version": "5.1.2",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
@@ -3202,7 +3187,6 @@
                 "string-width": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -3220,7 +3204,6 @@
                 "strip-ansi": {
                     "version": "3.0.1",
                     "bundled": true,
-                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -3259,13 +3242,11 @@
                 },
                 "wrappy": {
                     "version": "1.0.2",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "yallist": {
                     "version": "3.0.3",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 }
             }
         },
@@ -6922,12 +6903,12 @@
             "from": "github:CriminalInjuriesCompensationAuthority/q-base-config#semver:<1.0.0",
             "dev": true,
             "requires": {
-                "module-zero": "github:webstacker/module-zero"
+                "module-zero": "github:webstacker/module-zero#009ebafa93c518e4326199963882c40fd85113d7"
             }
         },
         "q-transformer": {
-            "version": "git+https://github.com/CriminalInjuriesCompensationAuthority/q-transformer.git#070a93ae222f49c5e6329794cf31a2b2d1b65a41",
-            "from": "git+https://github.com/CriminalInjuriesCompensationAuthority/q-transformer.git#BP03-autocomplete",
+            "version": "git+https://github.com/CriminalInjuriesCompensationAuthority/q-transformer.git#0bbe62f67275aebb1f6ebdbea6230ee58731b371",
+            "from": "git+https://github.com/CriminalInjuriesCompensationAuthority/q-transformer.git",
             "requires": {
                 "lodash.merge": "^4.6.1",
                 "moment": "^2.24.0"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
         "start:dev": "nodemon -L --inspect=0.0.0.0:9229 -e .js,.json,.njk ./bin/www",
         "start": "node ./bin/www",
         "sass": "node-sass src/sass/all.scss public/stylesheets/all.css && node-sass src/sass/all-ie8.scss public/stylesheets/all-ie8.css",
-        "test": "jest"
+        "test": "jest",
+        "coverage": "jest --coverage"
     },
     "dependencies": {
         "client-sessions": "^0.8.0",

--- a/test/test-fixtures/res/progress_entry_example.json
+++ b/test/test-fixtures/res/progress_entry_example.json
@@ -1,4 +1,5 @@
 {
+    "statusCode": 201,
     "body": {
         "data": [
             {


### PR DESCRIPTION
If changing an answer from the check-your-answers page results in a cascading effect, the client can't be redirected back to the check-your-answers page. Currently this results in 404 page not found.

This pull request changes that behaviour to go to the "current" page if the check-your-answers redirect is unavailable. 