### PR TITLE
Update validation

### DIFF
--- a/index/start-page.njk
+++ b/index/start-page.njk
@@ -18,7 +18,7 @@
         <li>you paid for the funeral of someone who died because of a violent crime</li>
         </ul>
         <p class="govuk-body">You cannot get compensation if the crime has not been reported to the police</p>
-        <p class="govuk-body">The crime must have happened in England, Wales, Scotland or <a href="">another relevant place.</a></p>
+        <p class="govuk-body">The crime must have happened in England, Wales, Scotland or <a href="https://www.gov.uk/guidance/criminal-injuries-compensation-a-guide#incident-location">another relevant place.</a></p>
         <p class="govuk-body">There is a different service for <a href="https://www.justice-ni.gov.uk/topics/justice-and-law/compensation-services">Northern Ireland</a>.</p>
         <form name="questionnaire-form" id="questionnaire-form">
         {{

--- a/questionnaire/form-helper.js
+++ b/questionnaire/form-helper.js
@@ -59,7 +59,7 @@ function renderSection(
                 {% endif %}
             {% endblock %}
             {% block innerContent %}
-                <form method="post" {%- if ${isSummary} %} action="/apply/submission/confirm"{% endif %}>
+                <form method="post" {%- if ${isSummary} %} action="/apply/submission/confirm"{% endif %} novalidate>
                     {% from "button/macro.njk" import govukButton %}
                         ${transformation}
                     {% if ${showButton} %}   

--- a/questionnaire/questionnaireUISchema.js
+++ b/questionnaire/questionnaireUISchema.js
@@ -348,5 +348,19 @@ module.exports = {
                 }
             }
         }
+    },
+    'p-applicant-enter-your-email-address': {
+        options: {
+            properties: {
+                'q-applicant-enter-your-email-address': {
+                    options: {
+                        autocomplete: 'email',
+                        attributes: {
+                            spellcheck: 'false'
+                        }
+                    }
+                }
+            }
+        }
     }
 };

--- a/test/test-fixtures/transformations/resolved html/p-applicant-british-citizen-or-eu-national.js
+++ b/test/test-fixtures/transformations/resolved html/p-applicant-british-citizen-or-eu-national.js
@@ -124,7 +124,7 @@ const html = `<!DOCTYPE html>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
 
-                <form method="post">
+                <form method="post" novalidate>
 
 
 


### PR DESCRIPTION
The commit adds the 'novalidate' property to the form, as well
as disabling the spellcheck attribute. This will disable the 
browser's default validation to allow the schema to
validate the users email address. Tests were updated to reflect
this change.

Finally, this commit also adds the correct link to the "another
relevant place" link on the start page.