### PR TITLE
Ensure cookie timeout does not exceed activeDuration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1439,11 +1439,10 @@
             "dev": true
         },
         "client-sessions": {
-            "version": "0.8.0",
-            "resolved": "https://registry.npmjs.org/client-sessions/-/client-sessions-0.8.0.tgz",
-            "integrity": "sha1-p9jFVYrV1W8qGZ81M+tlS134k/0=",
+            "version": "github:CriminalInjuriesCompensationAuthority/node-client-sessions#71dc1e4b42cce86f411664aa7bf323d6a9d9ad90",
+            "from": "github:CriminalInjuriesCompensationAuthority/node-client-sessions#v0.9.0",
             "requires": {
-                "cookies": "^0.7.0"
+                "cookies": "^0.7.3"
             }
         },
         "cliui": {
@@ -2290,9 +2289,9 @@
             }
         },
         "eslint-utils": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.0.tgz",
-            "integrity": "sha512-7ehnzPaP5IIEh1r1tkjuIrxqhNkzUJa9z3R92tLJdZIVdWaczEhr3EbhGtsMrVxi1KeR8qA7Off6SWc5WNQqyQ==",
+            "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
+            "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
             "dev": true,
             "requires": {
                 "eslint-visitor-keys": "^1.0.0"
@@ -2805,8 +2804,7 @@
                 },
                 "ansi-regex": {
                     "version": "2.1.1",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -2824,13 +2822,11 @@
                 },
                 "balanced-match": {
                     "version": "1.0.0",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
-                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -2843,18 +2839,15 @@
                 },
                 "code-point-at": {
                     "version": "1.1.0",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -2957,8 +2950,7 @@
                 },
                 "inherits": {
                     "version": "2.0.3",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -2968,7 +2960,6 @@
                 "is-fullwidth-code-point": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -2981,20 +2972,17 @@
                 "minimatch": {
                     "version": "3.0.4",
                     "bundled": true,
-                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
                 },
                 "minimist": {
                     "version": "0.0.8",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "minipass": {
                     "version": "2.3.5",
                     "bundled": true,
-                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
@@ -3011,7 +2999,6 @@
                 "mkdirp": {
                     "version": "0.5.1",
                     "bundled": true,
-                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -3084,8 +3071,7 @@
                 },
                 "number-is-nan": {
                     "version": "1.0.1",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -3095,7 +3081,6 @@
                 "once": {
                     "version": "1.4.0",
                     "bundled": true,
-                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -3171,8 +3156,7 @@
                 },
                 "safe-buffer": {
                     "version": "5.1.2",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
@@ -3202,7 +3186,6 @@
                 "string-width": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -3220,7 +3203,6 @@
                 "strip-ansi": {
                     "version": "3.0.1",
                     "bundled": true,
-                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -3259,13 +3241,11 @@
                 },
                 "wrappy": {
                     "version": "1.0.2",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "yallist": {
                     "version": "3.0.3",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 }
             }
         },
@@ -6922,7 +6902,7 @@
             "from": "github:CriminalInjuriesCompensationAuthority/q-base-config#semver:<1.0.0",
             "dev": true,
             "requires": {
-                "module-zero": "github:webstacker/module-zero"
+                "module-zero": "github:webstacker/module-zero#009ebafa93c518e4326199963882c40fd85113d7"
             }
         },
         "q-transformer": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "coverage": "jest --coverage"
     },
     "dependencies": {
-        "client-sessions": "^0.8.0",
+        "client-sessions": "github:CriminalInjuriesCompensationAuthority/node-client-sessions#v0.9.0",
         "cookie-parser": "~1.4.3",
         "debug": "~2.6.9",
         "express": "~4.16.0",


### PR DESCRIPTION
Given a cookie that will last for 1000ms without interaction. If the user interacts with the cookie within this time it will be extended by a further 1000ms (activeDuration). However, the current remaining time + activeDuration should NOT exceed activeDuration e.g.

activeDuration is set at 1000ms. Cookie expires in 1000ms. User interacts with 500ms remaining. The cookie will be set to expire in 1000ms, NOT 1500ms.

Given the current 1500ms behaviour, this can lead to situations where an unsubmitted questionnaire is deleted after 15mins but the session is still active, causing a 404 error. This PR fixes that behaviour.