### PR TITLE
Update prod kube files

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -7,6 +7,15 @@ const config = {
 };
 /*! m0-end */
 
+config.overrides = [
+    {
+        files: ['*.yaml', '*.yml'],
+        options: {
+            tabWidth: 2
+        }
+    }
+];
+
 /*! m0-start */
 module.exports = config;
 /*! m0-end */

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -5,4 +5,4 @@ jest.testEnvironment = 'node';
 process.env.DATA_CAPTURE_SERVICE = 'some_token';
 process.env.DCS_JWT = 'A massive string';
 process.env.CW_COOKIE_SECRET = 'Also a huge string';
-process.env.CW_DCS_URL = 'http://docker.for.win.localhost:3100/api/v1';
+process.env.CW_DCS_URL = 'http://docker.for.win.localhost:3100';

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -2,7 +2,6 @@
 
 jest.setTimeout(30000);
 jest.testEnvironment = 'node';
-process.env.DATA_CAPTURE_SERVICE = 'some_token';
-process.env.DCS_JWT = 'A massive string';
+process.env.CW_DCS_JWT = 'A massive string';
 process.env.CW_COOKIE_SECRET = 'Also a huge string';
 process.env.CW_DCS_URL = 'http://docker.for.win.localhost:3100';

--- a/kube_deploy/Production/deploy.yml
+++ b/kube_deploy/Production/deploy.yml
@@ -10,8 +10,21 @@ spec:
         app: webapp-prod
     spec:
       containers:
-      - name: webapp 
-        image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/cica/cica-repo-uat:latest
-        imagePullPolicy: Always
-        ports:
-        - containerPort: 3000
+        - name: webapp
+          image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/cica/cica-repo-prod:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 3000
+          env:
+            - name: CW_DCS_URL
+              value: https://data-capture-service.claim-criminal-injuries-compensation.service.justice.gov.uk
+            - name: CW_DCS_JWT
+              valueFrom:
+                secretKeyRef:
+                  name: cica-web-secrets
+                  key: cw_dcs_jwt
+            - name: CW_COOKIE_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: cica-web-secrets
+                  key: cw_cookie_secret

--- a/kube_deploy/Uat/deploy.yml
+++ b/kube_deploy/Uat/deploy.yml
@@ -1,30 +1,30 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-    name: webapp-uat
+  name: webapp-uat
 spec:
-    replicas: 1
-    template:
-        metadata:
-            labels:
-                app: webapp-uat
-        spec:
-            containers:
-                - name: webapp
-                  image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/cica/cica-repo-uat:latest
-                  imagePullPolicy: Always
-                  ports:
-                      - containerPort: 3000
-                  env:
-                      - name: CW_DCS_URL
-                        value: https://data-capture-service.uat.claim-criminal-injuries-compensation.service.justice.gov.uk/api/v1
-                      - name: CW_DCS_JWT
-                        valueFrom:
-                            secretKeyRef:
-                                name: cw-dcs-jwt
-                                key: secret
-                      - name: CW_COOKIE_SECRET
-                        valueFrom:
-                            secretKeyRef:
-                                name: cw-cookie-secret
-                                key: secret
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: webapp-uat
+    spec:
+      containers:
+        - name: webapp
+          image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/cica/cica-repo-uat:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 3000
+          env:
+            - name: CW_DCS_URL
+              value: https://data-capture-service.uat.claim-criminal-injuries-compensation.service.justice.gov.uk
+            - name: CW_DCS_JWT
+              valueFrom:
+                secretKeyRef:
+                  name: cw-dcs-jwt
+                  key: secret
+            - name: CW_COOKIE_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: cw-cookie-secret
+                  key: secret

--- a/kube_deploy/Uat/deploy.yml
+++ b/kube_deploy/Uat/deploy.yml
@@ -21,10 +21,10 @@ spec:
             - name: CW_DCS_JWT
               valueFrom:
                 secretKeyRef:
-                  name: cw-dcs-jwt
-                  key: secret
+                  name: cica-web-secrets
+                  key: cw_dcs_jwt
             - name: CW_COOKIE_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: cw-cookie-secret
-                  key: secret
+                  name: cica-web-secrets
+                  key: cw_cookie_secret

--- a/questionnaire/questionnaire-service.js
+++ b/questionnaire/questionnaire-service.js
@@ -5,7 +5,7 @@ const service = require('./request-service')();
 function questionnaireService() {
     function createQuestionnaire() {
         const opts = {
-            url: `${process.env.CW_DCS_URL}/questionnaires`,
+            url: `${process.env.CW_DCS_URL}/api/v1/questionnaires`,
             headers: {
                 Authorization: `Bearer ${process.env.CW_DCS_JWT}`
             },
@@ -23,7 +23,7 @@ function questionnaireService() {
 
     function getSection(questionnaireId, section) {
         const opts = {
-            url: `${process.env.CW_DCS_URL}/questionnaires/${questionnaireId}/progress-entries?filter[sectionId]=${section}`,
+            url: `${process.env.CW_DCS_URL}/api/v1/questionnaires/${questionnaireId}/progress-entries?filter[sectionId]=${section}`,
             headers: {
                 Authorization: `Bearer ${process.env.CW_DCS_JWT}`
             }
@@ -33,7 +33,7 @@ function questionnaireService() {
 
     function postSection(questionnaireId, section, body) {
         const opts = {
-            url: `${process.env.CW_DCS_URL}/questionnaires/${questionnaireId}/sections/${section}/answers`,
+            url: `${process.env.CW_DCS_URL}/api/v1/questionnaires/${questionnaireId}/sections/${section}/answers`,
             headers: {
                 Authorization: `Bearer ${process.env.CW_DCS_JWT}`
             },
@@ -49,7 +49,7 @@ function questionnaireService() {
 
     function getPrevious(questionnaireId, sectionId) {
         const opts = {
-            url: `${process.env.CW_DCS_URL}/questionnaires/${questionnaireId}/progress-entries?page[before]=${sectionId}`,
+            url: `${process.env.CW_DCS_URL}/api/v1/questionnaires/${questionnaireId}/progress-entries?page[before]=${sectionId}`,
             headers: {
                 Authorization: `Bearer ${process.env.CW_DCS_JWT}`
             }
@@ -59,7 +59,7 @@ function questionnaireService() {
 
     function getCurrentSection(currentQuestionnaireId) {
         const opts = {
-            url: `${process.env.CW_DCS_URL}/questionnaires/${currentQuestionnaireId}/progress-entries?filter[position]=current`,
+            url: `${process.env.CW_DCS_URL}/api/v1/questionnaires/${currentQuestionnaireId}/progress-entries?filter[position]=current`,
             headers: {
                 Authorization: `Bearer ${process.env.CW_DCS_JWT}`
             }
@@ -69,7 +69,7 @@ function questionnaireService() {
 
     function getSubmission(questionnaireId) {
         const opts = {
-            url: `${process.env.CW_DCS_URL}/questionnaires/${questionnaireId}/submissions`,
+            url: `${process.env.CW_DCS_URL}/api/v1/questionnaires/${questionnaireId}/submissions`,
             headers: {
                 Authorization: `Bearer ${process.env.CW_DCS_JWT}`
             }
@@ -79,7 +79,7 @@ function questionnaireService() {
 
     function postSubmission(questionnaireId) {
         const opts = {
-            url: `${process.env.CW_DCS_URL}/questionnaires/${questionnaireId}/submissions`,
+            url: `${process.env.CW_DCS_URL}/api/v1/questionnaires/${questionnaireId}/submissions`,
             headers: {
                 Authorization: `Bearer ${process.env.CW_DCS_JWT}`
             },
@@ -120,7 +120,7 @@ function questionnaireService() {
 
     function getAnswers(questionnaireId) {
         const opts = {
-            url: `${process.env.CW_DCS_URL}/questionnaires/${questionnaireId}/sections/answers`,
+            url: `${process.env.CW_DCS_URL}/api/v1/questionnaires/${questionnaireId}/sections/answers`,
             headers: {
                 Authorization: `Bearer ${process.env.CW_DCS_JWT}`
             }
@@ -130,7 +130,7 @@ function questionnaireService() {
 
     function getFirstSection(currentQuestionnaireId) {
         const opts = {
-            url: `${process.env.CW_DCS_URL}/questionnaires/${currentQuestionnaireId}/progress-entries?filter[position]=first`,
+            url: `${process.env.CW_DCS_URL}/api/v1/questionnaires/${currentQuestionnaireId}/progress-entries?filter[position]=first`,
             headers: {
                 Authorization: `Bearer ${process.env.CW_DCS_JWT}`
             }

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -924,7 +924,7 @@ describe('Data capture service endpoints', () => {
 
             it('should redirect to the prescribed next section id if available', async () => {
                 jest.doMock('../questionnaire/request-service', () => {
-                    const api = `${process.env.CW_DCS_URL}/questionnaires/c7f3b592-b7ac-4f2a-ab9c-8af407ade8cd`;
+                    const api = `${process.env.CW_DCS_URL}/api/v1/questionnaires/c7f3b592-b7ac-4f2a-ab9c-8af407ade8cd`;
 
                     return () => ({
                         post: options => {
@@ -971,7 +971,7 @@ describe('Data capture service endpoints', () => {
 
             it('should redirect to the current section if the prescribed next section id is not available', async () => {
                 jest.doMock('../questionnaire/request-service', () => {
-                    const api = `${process.env.CW_DCS_URL}/questionnaires/c7f3b592-b7ac-4f2a-ab9c-8af407ade8cd`;
+                    const api = `${process.env.CW_DCS_URL}/api/v1/questionnaires/c7f3b592-b7ac-4f2a-ab9c-8af407ade8cd`;
 
                     return () => ({
                         post: options => {


### PR DESCRIPTION
This PR updates the UAT secrets references and adds the missing references to the PROD deploy yaml. This branch has been deployed to both environments and is working as expected.

The kube deploy yaml files had inconsistent whitespace. I've updated the prettier config to ensure they're formatted with 2 spaces.