### PR TITLE
Update deployment yaml to use internal url for DCS

### DIFF
--- a/kube_deploy/Production/deploy.yml
+++ b/kube_deploy/Production/deploy.yml
@@ -17,7 +17,7 @@ spec:
             - containerPort: 3000
           env:
             - name: CW_DCS_URL
-              value: https://data-capture-service.claim-criminal-injuries-compensation.service.justice.gov.uk
+              value: http://dcs-service-prod
             - name: CW_DCS_JWT
               valueFrom:
                 secretKeyRef:

--- a/kube_deploy/Uat/deploy.yml
+++ b/kube_deploy/Uat/deploy.yml
@@ -17,7 +17,7 @@ spec:
             - containerPort: 3000
           env:
             - name: CW_DCS_URL
-              value: https://data-capture-service.uat.claim-criminal-injuries-compensation.service.justice.gov.uk
+              value: http://dcs-service-uat
             - name: CW_DCS_JWT
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
Currently CW communicates with DCS over https. This PR uses the internal service URL instead.