### PR TITLE
Remove hard-coded answer lookups from q-transformer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1078,6 +1078,11 @@
                 "type-is": "~1.6.16"
             }
         },
+        "bowser": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.7.0.tgz",
+            "integrity": "sha512-aIlMvstvu8x+34KEiOHD3AsBgdrzg6sxALYiukOWhFvGMbQI6TRP/iY0LMhUrHs56aD6P1G0Z7h45PUJaa5m9w=="
+        },
         "boxen": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
@@ -1579,9 +1584,9 @@
             "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
         },
         "content-security-policy-builder": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/content-security-policy-builder/-/content-security-policy-builder-2.0.0.tgz",
-            "integrity": "sha512-j+Nhmj1yfZAikJLImCvPJFE29x/UuBi+/MWqggGGc515JKaZrjuei2RhULJmy0MsstW3E3htl002bwmBNMKr7w=="
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/content-security-policy-builder/-/content-security-policy-builder-2.1.0.tgz",
+            "integrity": "sha512-/MtLWhJVvJNkA9dVLAp6fg9LxD2gfI6R2Fi1hPmfjYXSahJJzcfvoeDOxSyp4NvxMuwWv3WMssE9o31DoULHrQ=="
         },
         "content-type": {
             "version": "1.0.4",
@@ -2854,7 +2859,8 @@
                 },
                 "ansi-regex": {
                     "version": "2.1.1",
-                    "bundled": true
+                    "bundled": true,
+                    "optional": true
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -2872,11 +2878,13 @@
                 },
                 "balanced-match": {
                     "version": "1.0.0",
-                    "bundled": true
+                    "bundled": true,
+                    "optional": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
+                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -2889,15 +2897,18 @@
                 },
                 "code-point-at": {
                     "version": "1.1.0",
-                    "bundled": true
+                    "bundled": true,
+                    "optional": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
-                    "bundled": true
+                    "bundled": true,
+                    "optional": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
-                    "bundled": true
+                    "bundled": true,
+                    "optional": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -3000,7 +3011,8 @@
                 },
                 "inherits": {
                     "version": "2.0.3",
-                    "bundled": true
+                    "bundled": true,
+                    "optional": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -3010,6 +3022,7 @@
                 "is-fullwidth-code-point": {
                     "version": "1.0.0",
                     "bundled": true,
+                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -3022,17 +3035,20 @@
                 "minimatch": {
                     "version": "3.0.4",
                     "bundled": true,
+                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
                 },
                 "minimist": {
                     "version": "0.0.8",
-                    "bundled": true
+                    "bundled": true,
+                    "optional": true
                 },
                 "minipass": {
                     "version": "2.3.5",
                     "bundled": true,
+                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
@@ -3049,6 +3065,7 @@
                 "mkdirp": {
                     "version": "0.5.1",
                     "bundled": true,
+                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -3121,7 +3138,8 @@
                 },
                 "number-is-nan": {
                     "version": "1.0.1",
-                    "bundled": true
+                    "bundled": true,
+                    "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -3131,6 +3149,7 @@
                 "once": {
                     "version": "1.4.0",
                     "bundled": true,
+                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -3206,7 +3225,8 @@
                 },
                 "safe-buffer": {
                     "version": "5.1.2",
-                    "bundled": true
+                    "bundled": true,
+                    "optional": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
@@ -3236,6 +3256,7 @@
                 "string-width": {
                     "version": "1.0.2",
                     "bundled": true,
+                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -3253,6 +3274,7 @@
                 "strip-ansi": {
                     "version": "3.0.1",
                     "bundled": true,
+                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -3291,11 +3313,13 @@
                 },
                 "wrappy": {
                     "version": "1.0.2",
-                    "bundled": true
+                    "bundled": true,
+                    "optional": true
                 },
                 "yallist": {
                     "version": "3.0.3",
-                    "bundled": true
+                    "bundled": true,
+                    "optional": true
                 }
             }
         },
@@ -3512,9 +3536,9 @@
             "dev": true
         },
         "handlebars": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
-            "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+            "version": "4.5.1",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.1.tgz",
+            "integrity": "sha512-C29UoFzHe9yM61lOsIlCE5/mQVGrnIOrOq7maQl76L7tYPCgC1og0Ajt6uWnX4ZTxBPnjw+CUvawphwCfJgUnA==",
             "dev": true,
             "requires": {
                 "neo-async": "^2.6.0",
@@ -3613,9 +3637,9 @@
             }
         },
         "helmet": {
-            "version": "3.19.0",
-            "resolved": "https://registry.npmjs.org/helmet/-/helmet-3.19.0.tgz",
-            "integrity": "sha512-l58Q3unSpYatlurvFzkCbTRQ8oWUmdXbOs7h+pnwQbFJRhRJDjER6UMyqHxp9iFtWPcVA05VLcUGSi0EXIv7GA==",
+            "version": "3.21.2",
+            "resolved": "https://registry.npmjs.org/helmet/-/helmet-3.21.2.tgz",
+            "integrity": "sha512-okUo+MeWgg00cKB8Csblu8EXgcIoDyb5ZS/3u0W4spCimeVuCUvVZ6Vj3O2VJ1Sxpyb8jCDvzu0L1KKT11pkIg==",
             "requires": {
                 "depd": "2.0.0",
                 "dns-prefetch-control": "0.2.0",
@@ -3624,14 +3648,14 @@
                 "feature-policy": "0.3.0",
                 "frameguard": "3.1.0",
                 "helmet-crossdomain": "0.4.0",
-                "helmet-csp": "2.7.1",
+                "helmet-csp": "2.9.4",
                 "hide-powered-by": "1.1.0",
                 "hpkp": "2.0.0",
                 "hsts": "2.2.0",
                 "ienoopen": "1.1.0",
                 "nocache": "2.1.0",
                 "referrer-policy": "1.2.0",
-                "x-xss-protection": "1.2.0"
+                "x-xss-protection": "1.3.0"
             },
             "dependencies": {
                 "depd": {
@@ -3647,14 +3671,14 @@
             "integrity": "sha512-AB4DTykRw3HCOxovD1nPR16hllrVImeFp5VBV9/twj66lJ2nU75DP8FPL0/Jp4jj79JhTfG+pFI2MD02kWJ+fA=="
         },
         "helmet-csp": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/helmet-csp/-/helmet-csp-2.7.1.tgz",
-            "integrity": "sha512-sCHwywg4daQ2mY0YYwXSZRsgcCeerUwxMwNixGA7aMLkVmPTYBl7gJoZDHOZyXkqPrtuDT3s2B1A+RLI7WxSdQ==",
+            "version": "2.9.4",
+            "resolved": "https://registry.npmjs.org/helmet-csp/-/helmet-csp-2.9.4.tgz",
+            "integrity": "sha512-qUgGx8+yk7Xl8XFEGI4MFu1oNmulxhQVTlV8HP8tV3tpfslCs30OZz/9uQqsWPvDISiu/NwrrCowsZBhFADYqg==",
             "requires": {
+                "bowser": "^2.7.0",
                 "camelize": "1.0.0",
-                "content-security-policy-builder": "2.0.0",
-                "dasherize": "2.0.0",
-                "platform": "1.3.5"
+                "content-security-policy-builder": "2.1.0",
+                "dasherize": "2.0.0"
             }
         },
         "hide-powered-by": {
@@ -6074,6 +6098,11 @@
             "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
             "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
         },
+        "nanoid": {
+            "version": "2.1.6",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.6.tgz",
+            "integrity": "sha512-2NDzpiuEy3+H0AVtdt8LoFi7PnqkOnIzYmJQp7xsEU6VexLluHQwKREuiz57XaQC5006seIadPrIZJhyS2n7aw=="
+        },
         "nanomatch": {
             "version": "1.2.13",
             "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -6807,11 +6836,6 @@
                 "find-up": "^2.1.0"
             }
         },
-        "platform": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.5.tgz",
-            "integrity": "sha512-TuvHS8AOIZNAlE77WUDiR4rySV/VMptyMfcfeoMgs4P8apaZM3JrnbzBiixKUv+XR6i+BXrQh8WAnjaSPFO65Q=="
-        },
         "please-upgrade-node": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.1.1.tgz",
@@ -6952,15 +6976,16 @@
             "from": "github:CriminalInjuriesCompensationAuthority/q-base-config#semver:<1.0.0",
             "dev": true,
             "requires": {
-                "module-zero": "github:webstacker/module-zero#009ebafa93c518e4326199963882c40fd85113d7"
+                "module-zero": "github:webstacker/module-zero"
             }
         },
         "q-transformer": {
-            "version": "git+https://github.com/CriminalInjuriesCompensationAuthority/q-transformer.git#0bbe62f67275aebb1f6ebdbea6230ee58731b371",
-            "from": "git+https://github.com/CriminalInjuriesCompensationAuthority/q-transformer.git",
+            "version": "github:CriminalInjuriesCompensationAuthority/q-transformer#78dfe96f5412ba3e0bfbc5d1528c31aa068d89aa",
+            "from": "github:CriminalInjuriesCompensationAuthority/q-transformer#uischemaUpdate",
             "requires": {
                 "lodash.merge": "^4.6.1",
-                "moment": "^2.24.0"
+                "moment": "^2.24.0",
+                "nanoid": "^2.1.1"
             }
         },
         "qs": {
@@ -9021,9 +9046,9 @@
             }
         },
         "x-xss-protection": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/x-xss-protection/-/x-xss-protection-1.2.0.tgz",
-            "integrity": "sha512-xN0kV+8XfOQM2OPPBdEbGtbvJNNP1pvZR7sE6d44cjJFQG4OiGDdienPg5iOUGswBTiGbBvtYDURd30BMJwwqg=="
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/x-xss-protection/-/x-xss-protection-1.3.0.tgz",
+            "integrity": "sha512-kpyBI9TlVipZO4diReZMAHWtS0MMa/7Kgx8hwG/EuZLiA6sg4Ah/4TRdASHhRRN3boobzcYgFRUFSgHRge6Qhg=="
         },
         "xdg-basedir": {
             "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "moment": "^2.24.0",
         "morgan": "~1.9.0",
         "nunjucks": "^3.1.7",
-        "q-transformer": "github:CriminalInjuriesCompensationAuthority/q-transformer.git#v0.7.1"
+        "q-transformer": "github:CriminalInjuriesCompensationAuthority/q-transformer.git#v0.7.2"
     },
     "devDependencies": {
         "eslint": "^5.8.0",

--- a/questionnaire/questionnaireUISchema.js
+++ b/questionnaire/questionnaireUISchema.js
@@ -168,172 +168,203 @@ module.exports = {
                         summaryStructure: [
                             {
                                 title: 'Your details',
-                                questions: [
-                                    'p-applicant-enter-your-name',
-                                    'p-applicant-have-you-been-known-by-any-other-names',
-                                    'p-applicant-what-other-names-have-you-used',
-                                    'p-applicant-enter-your-date-of-birth',
-                                    'p-applicant-enter-your-email-address',
-                                    'p-applicant-enter-your-address',
-                                    'p-applicant-enter-your-telephone-number',
-                                    'p-applicant-british-citizen-or-eu-national',
-                                    'p-applicant-are-you-18-or-over',
-                                    'p-applicant-who-are-you-applying-for',
-                                    'p-applicant-were-you-a-victim-of-sexual-assault-or-abuse',
-                                    'p-applicant-select-the-option-that-applies-to-you'
-                                ]
+                                questions: {
+                                    'p-applicant-enter-your-name': 'Name',
+
+                                    'p-applicant-have-you-been-known-by-any-other-names':
+                                        'Have you been known by any other names?',
+                                    'p-applicant-what-other-names-have-you-used': 'Other names',
+                                    'p-applicant-enter-your-date-of-birth': 'Date of birth',
+                                    'p-applicant-enter-your-email-address': 'Email address',
+                                    'p-applicant-enter-your-address': 'Address',
+                                    'p-applicant-enter-your-telephone-number': 'Telephone Number',
+
+                                    'p-applicant-british-citizen-or-eu-national':
+                                        'Are you a British citizen or EU National?',
+                                    'p-applicant-are-you-18-or-over': 'Are you 18 or over?',
+
+                                    'p-applicant-who-are-you-applying-for':
+                                        'Who are you applying for?',
+                                    'p-applicant-were-you-a-victim-of-sexual-assault-or-abuse':
+                                        'Were you a victim of sexual assault or abuse?',
+                                    'p-applicant-select-the-option-that-applies-to-you':
+                                        "Option you've selected"
+                                }
                             },
                             {
                                 title: 'About the crime',
-                                questions: [
-                                    'p-applicant-did-the-crime-happen-once-or-over-time',
-                                    'p-applicant-when-did-the-crime-happen',
-                                    'p-applicant-when-did-the-crime-start',
-                                    'p-applicant-when-did-the-crime-stop',
-                                    'p-applicant-select-reasons-for-the-delay-in-making-your-application',
-                                    'p-applicant-where-did-the-crime-happen',
-                                    'p-applicant-where-in-england-did-it-happen',
-                                    'p-applicant-where-in-scotland-did-it-happen',
-                                    'p-applicant-where-in-wales-did-it-happen',
-                                    'p-offender-do-you-know-the-name-of-the-offender',
-                                    'p-offender-enter-offenders-name',
-                                    'p-offender-describe-contact-with-offender'
-                                ]
+                                questions: {
+                                    'p-applicant-did-the-crime-happen-once-or-over-time':
+                                        'Did the crime happen once or over a period of time?',
+                                    'p-applicant-when-did-the-crime-happen':
+                                        'When did the crime happen?',
+                                    'p-applicant-when-did-the-crime-start':
+                                        'When did the crime start?',
+                                    'p-applicant-when-did-the-crime-stop':
+                                        'When did the crime stop?',
+                                    'p-applicant-select-reasons-for-the-delay-in-making-your-application':
+                                        'Reasons for the delay in making your application',
+                                    'p-applicant-where-did-the-crime-happen':
+                                        'Where did the crime happen?',
+                                    'p-applicant-where-in-england-did-it-happen':
+                                        'Where in England did it happen?',
+                                    'p-applicant-where-in-scotland-did-it-happen':
+                                        'Where in Scotland did it happen?',
+                                    'p-applicant-where-in-wales-did-it-happen':
+                                        'Where in Wales did it happen?',
+                                    'p-offender-do-you-know-the-name-of-the-offender':
+                                        'Do you know the name of the offender?',
+                                    'p-offender-enter-offenders-name': "Offender's name",
+
+                                    'p-offender-describe-contact-with-offender':
+                                        'Contact with offender'
+                                }
                             },
                             {
                                 title: 'Police report',
-                                questions: [
-                                    'p--was-the-crime-reported-to-police',
-                                    'p--when-was-the-crime-reported-to-police',
-                                    'p--whats-the-crime-reference-number',
-                                    'p--which-english-police-force-is-investigating-the-crime',
-                                    'p--which-police-scotland-division-is-investigating-the-crime',
-                                    'p--which-welsh-police-force-is-investigating-the-crime',
-                                    'p-applicant-select-reasons-for-the-delay-in-reporting-the-crime-to-police'
-                                ]
+                                questions: {
+                                    'p--was-the-crime-reported-to-police':
+                                        'Was the crime reported to police?',
+                                    'p--when-was-the-crime-reported-to-police':
+                                        'When was the crime reported?',
+                                    'p--whats-the-crime-reference-number': 'Crime reference number',
+                                    'p--which-english-police-force-is-investigating-the-crime':
+                                        'Which police force is investigating?',
+                                    'p--which-police-scotland-division-is-investigating-the-crime':
+                                        'Which police force is investigating?',
+                                    'p--which-welsh-police-force-is-investigating-the-crime':
+                                        'Which police force is investigating?',
+                                    'p-applicant-select-reasons-for-the-delay-in-reporting-the-crime-to-police':
+                                        'Reasons for delay in reporting crime'
+                                }
                             },
                             {
                                 title: 'Other compensation',
-                                questions: [
-                                    'p-applicant-have-you-applied-to-us-before',
-                                    'p-applicant-have-you-applied-for-or-received-any-other-compensation',
-                                    'p-applicant-other-compensation-details'
-                                ]
+                                questions: {
+                                    'p-applicant-have-you-applied-to-us-before':
+                                        'Have you applied before?',
+                                    'p-applicant-have-you-applied-for-or-received-any-other-compensation':
+                                        'Have you received other compensation?',
+                                    'p-applicant-other-compensation-details':
+                                        'Details of other compensation received'
+                                }
                             }
-                        ]
+                        ],
+                        lookup: {
+                            true: 'Yes',
+                            false: 'No',
+                            once: 'Once',
+                            'over-a-period-of-time': 'Over a period of time',
+                            'i-was-underage': 'I was under 18',
+                            'i-was-advised-to-wait': 'I was advised to wait',
+                            'medical-reasons': 'Medical reasons',
+                            'other-reasons': 'Other reasons',
+                            'i-was-under-18': 'I was under 18',
+                            'unable-to-report-crime': 'Unable to report the crime',
+                            other: 'Other reasons',
+                            'option-1:-sexual-assault-or-abuse':
+                                'Option 1: Sexual assault or abuse',
+                            'option-2:-sexual-assault-or-abuse-and-other-injuries-or-losses':
+                                'Option 2: Sexual assault or abuse and other injuries or losses',
+                            myself: 'Myself',
+                            'someone-else': 'Someone else',
+                            england: 'England',
+                            scotland: 'Scotland',
+                            wales: 'Wales',
+                            'somewhere-else': 'Somewhere else',
+                            'i-have-no-contact-with-the-offender':
+                                'I have no contact with the offender',
+                            10000033: 'Avon And Somerset Constabulary',
+                            10000035: 'Bedfordshire Police',
+                            10000001: 'British Transport Police',
+                            10000039: 'Cambridgeshire Constabulary',
+                            10000049: 'Cheshire Constabulary',
+                            10000059: 'City Of London Police',
+                            10000066: 'Cleveland Police',
+                            10000082: 'Cumbria Constabulary',
+                            10000084: 'Derbyshire Constabulary',
+                            10000090: 'Devon & Cornwall Constabulary',
+                            10000093: 'Dorset Police',
+                            10000102: 'Durham Constabulary',
+                            10000109: 'Dyfed Powys Police',
+                            10000114: 'Essex Police',
+                            10000128: 'Gloucestershire Constabulary',
+                            10000140: 'Greater Manchester Police',
+                            10000147: 'Gwent Constabulary',
+                            10000150: 'Hampshire Constabulary',
+                            10000153: 'Hertfordshire Constabulary',
+                            10000169: 'Humberside Police',
+                            10000172: 'Kent County Constabulary',
+                            10000175: 'Lancashire Constabulary',
+                            10000176: 'Leicestershire Police',
+                            10000179: 'Lincolnshire Police',
+                            10000181: 'Merseyside Police',
+                            11809785: 'Metropolitan Barking',
+                            11809719: 'Metropolitan Barnet',
+                            11809788: 'Metropolitan Bexley',
+                            11809722: 'Metropolitan Brent',
+                            11809760: 'Metropolitan Bromley',
+                            11809694: 'Metropolitan Camden',
+                            11809713: 'Metropolitan Croydon',
+                            11809743: 'Metropolitan Ealing',
+                            11809783: 'Metropolitan Enfield',
+                            11809709: 'Metropolitan Greenwich',
+                            11809763: 'Metropolitan Hackney',
+                            11809795: 'Metropolitan Hammersmith',
+                            11809738: 'Metropolitan Haringey',
+                            11809803: 'Metropolitan Harrow',
+                            11809800: 'Metropolitan Havering',
+                            11809775: 'Metropolitan Hillingdon',
+                            11809780: 'Metropolitan Hounslow',
+                            11809765: 'Metropolitan Islington',
+                            11809801: 'Metropolitan Kensington',
+                            11809865: 'Metropolitan Kingston',
+                            11809693: 'Metropolitan Lambeth',
+                            11809698: 'Metropolitan Lewisham',
+                            11809861: 'Metropolitan Merton',
+                            11809701: 'Metropolitan Newham',
+                            11809782: 'Metropolitan Redbridge',
+                            11809862: 'Metropolitan Richmond',
+                            11809691: 'Metropolitan Southwark',
+                            11809805: 'Metropolitan Sutton',
+                            11809767: 'Metropolitan Tower Hamlets',
+                            11809726: 'Metropolitan Waltham Forest',
+                            11809771: 'Metropolitan Wandsworth',
+                            11809683: 'Metropolitan Westminster',
+                            10000185: 'Norfolk Constabulary',
+                            10000187: 'North Wales Police',
+                            10000189: 'North Yorkshire Police',
+                            10000191: 'Northamptonshire Police',
+                            10000195: 'Northumbria Police',
+                            10000199: 'Nottinghamshire Police',
+                            12607027: 'Scotland Argyll/West Dunbartonshire',
+                            12157147: 'Scotland Ayrshire',
+                            10000098: 'Scotland Dumfries & Galloway',
+                            13400412: 'Scotland Edinburgh City',
+                            10002424: 'Scotland Fife',
+                            10000045: 'Scotland Forth Valley',
+                            12607023: 'Scotland Greater Glasgow',
+                            10000193: 'Scotland Highlands And Islands',
+                            12607028: 'Scotland Lanarkshire',
+                            13400413: 'Scotland Lothian And Borders',
+                            10000133: 'Scotland North East',
+                            12607026: 'Scotland Renfrewshire/Inverclyde',
+                            10000243: 'Scotland Tayside',
+                            10000215: 'South Wales Police',
+                            10000218: 'South Yorkshire Police',
+                            10000223: 'Staffordshire Police',
+                            10000233: 'Suffolk Constabulary',
+                            10000237: 'Surrey Constabulary',
+                            10000240: 'Sussex Police',
+                            10000247: 'Thames Valley Police',
+                            10000274: 'Warwickshire Constabulary',
+                            10000279: 'West Mercia Police',
+                            10000285: 'West Midlands Police',
+                            10000291: 'West Yorkshire Police',
+                            10000295: 'Wiltshire Constabulary'
+                        }
                     }
                 }
-            },
-            lookup: {
-                true: 'Yes',
-                false: 'No',
-                once: 'Once',
-                'over-a-period-of-time': 'Over a period of time',
-                'i-was-underage': 'I was under 18',
-                'i-was-advised-to-wait': 'I was advised to wait',
-                'medical-reasons': 'Medical reasons',
-                'other-reasons': 'Other reasons',
-                'i-was-under-18': 'I was under 18',
-                'unable-to-report-crime': 'Unable to report the crime',
-                other: 'Other reasons',
-                'option-1:-sexual-assault-or-abuse': 'Option 1: Sexual assault or abuse',
-                'option-2:-sexual-assault-or-abuse-and-other-injuries-or-losses':
-                    'Option 2: Sexual assault or abuse and other injuries or losses',
-                myself: 'Myself',
-                'someone-else': 'Someone else',
-                england: 'England',
-                scotland: 'Scotland',
-                wales: 'Wales',
-                'somewhere-else': 'Somewhere else',
-                'i-have-no-contact-with-the-offender': 'I have no contact with the offender',
-                10000033: 'Avon And Somerset Constabulary',
-                10000035: 'Bedfordshire Police',
-                10000001: 'British Transport Police',
-                10000039: 'Cambridgeshire Constabulary',
-                10000049: 'Cheshire Constabulary',
-                10000059: 'City Of London Police',
-                10000066: 'Cleveland Police',
-                10000082: 'Cumbria Constabulary',
-                10000084: 'Derbyshire Constabulary',
-                10000090: 'Devon & Cornwall Constabulary',
-                10000093: 'Dorset Police',
-                10000102: 'Durham Constabulary',
-                10000109: 'Dyfed Powys Police',
-                10000114: 'Essex Police',
-                10000128: 'Gloucestershire Constabulary',
-                10000140: 'Greater Manchester Police',
-                10000147: 'Gwent Constabulary',
-                10000150: 'Hampshire Constabulary',
-                10000153: 'Hertfordshire Constabulary',
-                10000169: 'Humberside Police',
-                10000172: 'Kent County Constabulary',
-                10000175: 'Lancashire Constabulary',
-                10000176: 'Leicestershire Police',
-                10000179: 'Lincolnshire Police',
-                10000181: 'Merseyside Police',
-                11809785: 'Metropolitan Barking',
-                11809719: 'Metropolitan Barnet',
-                11809788: 'Metropolitan Bexley',
-                11809722: 'Metropolitan Brent',
-                11809760: 'Metropolitan Bromley',
-                11809694: 'Metropolitan Camden',
-                11809713: 'Metropolitan Croydon',
-                11809743: 'Metropolitan Ealing',
-                11809783: 'Metropolitan Enfield',
-                11809709: 'Metropolitan Greenwich',
-                11809763: 'Metropolitan Hackney',
-                11809795: 'Metropolitan Hammersmith',
-                11809738: 'Metropolitan Haringey',
-                11809803: 'Metropolitan Harrow',
-                11809800: 'Metropolitan Havering',
-                11809775: 'Metropolitan Hillingdon',
-                11809780: 'Metropolitan Hounslow',
-                11809765: 'Metropolitan Islington',
-                11809801: 'Metropolitan Kensington',
-                11809865: 'Metropolitan Kingston',
-                11809693: 'Metropolitan Lambeth',
-                11809698: 'Metropolitan Lewisham',
-                11809861: 'Metropolitan Merton',
-                11809701: 'Metropolitan Newham',
-                11809782: 'Metropolitan Redbridge',
-                11809862: 'Metropolitan Richmond',
-                11809691: 'Metropolitan Southwark',
-                11809805: 'Metropolitan Sutton',
-                11809767: 'Metropolitan Tower Hamlets',
-                11809726: 'Metropolitan Waltham Forest',
-                11809771: 'Metropolitan Wandsworth',
-                11809683: 'Metropolitan Westminster',
-                10000185: 'Norfolk Constabulary',
-                10000187: 'North Wales Police',
-                10000189: 'North Yorkshire Police',
-                10000191: 'Northamptonshire Police',
-                10000195: 'Northumbria Police',
-                10000199: 'Nottinghamshire Police',
-                12607027: 'Scotland Argyll/West Dunbartonshire',
-                12157147: 'Scotland Ayrshire',
-                10000098: 'Scotland Dumfries & Galloway',
-                13400412: 'Scotland Edinburgh City',
-                10002424: 'Scotland Fife',
-                10000045: 'Scotland Forth Valley',
-                12607023: 'Scotland Greater Glasgow',
-                10000193: 'Scotland Highlands And Islands',
-                12607028: 'Scotland Lanarkshire',
-                13400413: 'Scotland Lothian And Borders',
-                10000133: 'Scotland North East',
-                12607026: 'Scotland Renfrewshire/Inverclyde',
-                10000243: 'Scotland Tayside',
-                10000215: 'South Wales Police',
-                10000218: 'South Yorkshire Police',
-                10000223: 'Staffordshire Police',
-                10000233: 'Suffolk Constabulary',
-                10000237: 'Surrey Constabulary',
-                10000240: 'Sussex Police',
-                10000247: 'Thames Valley Police',
-                10000274: 'Warwickshire Constabulary',
-                10000279: 'West Mercia Police',
-                10000285: 'West Midlands Police',
-                10000291: 'West Yorkshire Police',
-                10000295: 'Wiltshire Constabulary'
             }
         }
     },


### PR DESCRIPTION
The commit includes work done to facilitate the removal of hard-coded
lookups from the q-transformer.

Linked to commit 147c629c42dad75dfc32ca47fb1b220b40f06bb3