### PR TITLE
Update enhanced select element ID

### DIFF
--- a/src/modules/autocomplete/autocomplete.js
+++ b/src/modules/autocomplete/autocomplete.js
@@ -66,7 +66,7 @@ function createAutocomplete(window) {
 
                 accessibleAutocomplete.enhanceSelectElement({
                     selectElement: selectElements[i],
-                    id: 'enhanced-dropdown-id',
+                    id: selectElements[i].id,
                     minLength: 2,
                     defaultValue: '',
                     autoselect: true,


### PR DESCRIPTION
Changed the ID of the generated autocomplete text input to be the same as the original select element ID. This allows the error message summary anchors to correctly link to the element in order or the user to gain focus on the element with the error. If JS is disabled, it will fall back to using the IDs generated in the q-transformer and will work as usual.