### PR TITLE
Increase replicas

### DIFF
--- a/kube_deploy/Production/deploy.yml
+++ b/kube_deploy/Production/deploy.yml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: webapp-prod
 spec:
-  replicas: 1
+  replicas: 4
   template:
     metadata:
       labels:

--- a/kube_deploy/Uat/deploy.yml
+++ b/kube_deploy/Uat/deploy.yml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: webapp-uat
 spec:
-  replicas: 1
+  replicas: 2
   template:
     metadata:
       labels:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cica-web",
-    "version": "0.0.0",
+    "version": "0.0.2",
     "private": true,
     "scripts": {
         "start:dev": "nodemon -L --inspect=0.0.0.0:9229 -e .css,.js,.json,.njk --ignore public/dist/ --exec npm run buildRun:dev",


### PR DESCRIPTION
Currently our PROD and UAT deployments have replicas set to 1. As per the guidance I have increase these to 4 for PROD:

https://user-guide.cloud-platform.service.justice.gov.uk/documentation/concepts/deploying.html#multiple-replicas

I've set UAT to 2 to ensure we're testing with multiple replicas.