### PR TITLE
Fix bug on confirmation

### DIFF
--- a/questionnaire/form-helper.js
+++ b/questionnaire/form-helper.js
@@ -26,7 +26,7 @@ function getButtonText(sectionId) {
         : 'Continue';
 }
 
-function checkIsSummary(sectionId) {
+function checkIsSummaryContext(sectionId) {
     return !!(
         sectionId in uiSchema &&
         uiSchema[sectionId].options &&
@@ -35,7 +35,7 @@ function checkIsSummary(sectionId) {
     );
 }
 
-function checkIsSubmission(sectionId) {
+function checkIsSubmissionContext(sectionId) {
     return !!(
         sectionId in uiSchema &&
         uiSchema[sectionId].options &&
@@ -54,7 +54,7 @@ function renderSection({
     cspNonce
 }) {
     const showButton = !isFinal;
-    const isSubmission = checkIsSubmission(sectionId);
+    const isSubmissionPage = checkIsSubmissionContext(sectionId);
     const buttonTitle = getButtonText(sectionId);
     const hasErrors = transformation.hasErrors === true;
     return nunjucks.renderString(
@@ -73,7 +73,7 @@ function renderSection({
                 {% endif %}
             {% endblock %}
             {% block innerContent %}
-                <form method="post" {%- if ${isSubmission} %} action="/apply/submission/confirm"{% endif %} novalidate>
+                <form method="post" {%- if ${isSubmissionPage} %} action="/apply/submission/confirm"{% endif %} novalidate>
                     {% from "button/macro.njk" import govukButton %}
                         ${transformation.content}
                     {% if ${showButton} %}
@@ -293,8 +293,8 @@ function getSectionHtmlWithErrors(sectionData, sectionId, csrfToken, cspNonce) {
 
 module.exports = {
     getButtonText,
-    checkIsSummary,
-    checkIsSubmission,
+    checkIsSummaryContext,
+    checkIsSubmissionContext,
     renderSection,
     removeSectionIdPrefix,
     processRequest,

--- a/questionnaire/form-helper.js
+++ b/questionnaire/form-helper.js
@@ -27,11 +27,21 @@ function getButtonText(sectionId) {
 }
 
 function checkIsSummary(sectionId) {
-    return sectionId in uiSchema &&
+    return !!(
+        sectionId in uiSchema &&
         uiSchema[sectionId].options &&
-        uiSchema[sectionId].options.isSummary
-        ? uiSchema[sectionId].options.isSummary
-        : false;
+        uiSchema[sectionId].options.pageContext &&
+        uiSchema[sectionId].options.pageContext === 'summary'
+    );
+}
+
+function checkIsSubmission(sectionId) {
+    return !!(
+        sectionId in uiSchema &&
+        uiSchema[sectionId].options &&
+        uiSchema[sectionId].options.pageContext &&
+        uiSchema[sectionId].options.pageContext === 'submission'
+    );
 }
 
 function renderSection({
@@ -44,7 +54,7 @@ function renderSection({
     cspNonce
 }) {
     const showButton = !isFinal;
-    const isSummary = checkIsSummary(sectionId);
+    const isSubmission = checkIsSubmission(sectionId);
     const buttonTitle = getButtonText(sectionId);
     const hasErrors = transformation.hasErrors === true;
     return nunjucks.renderString(
@@ -63,7 +73,7 @@ function renderSection({
                 {% endif %}
             {% endblock %}
             {% block innerContent %}
-                <form method="post" {%- if ${isSummary} %} action="/apply/submission/confirm"{% endif %} novalidate>
+                <form method="post" {%- if ${isSubmission} %} action="/apply/submission/confirm"{% endif %} novalidate>
                     {% from "button/macro.njk" import govukButton %}
                         ${transformation.content}
                     {% if ${showButton} %}
@@ -284,6 +294,7 @@ function getSectionHtmlWithErrors(sectionData, sectionId, csrfToken, cspNonce) {
 module.exports = {
     getButtonText,
     checkIsSummary,
+    checkIsSubmission,
     renderSection,
     removeSectionIdPrefix,
     processRequest,

--- a/questionnaire/questionnaireUISchema.js
+++ b/questionnaire/questionnaireUISchema.js
@@ -82,6 +82,7 @@ module.exports = {
     },
     'p--check-your-answers': {
         options: {
+            pageContext: 'summary',
             properties: {
                 'p-check-your-answers': {
                     options: {
@@ -524,7 +525,7 @@ module.exports = {
     'p-applicant-declaration': {
         options: {
             buttonText: 'Agree and submit',
-            isSummary: true
+            pageContext: 'submission'
         }
     }
 };

--- a/questionnaire/routes.js
+++ b/questionnaire/routes.js
@@ -47,9 +47,15 @@ router
             const response = await qService.getSection(req.cicaSession.questionnaireId, sectionId);
             if (
                 response.body.data &&
-                response.body.data[0].attributes.sectionId === response.body.meta.summary
+                response.body.data[0].attributes &&
+                response.body.data[0].attributes.sectionId
             ) {
-                answers = await qService.getAnswers(req.cicaSession.questionnaireId);
+                const isSummary = formHelper.checkIsSummary(
+                    response.body.data[0].attributes.sectionId
+                );
+                answers = isSummary
+                    ? await qService.getAnswers(req.cicaSession.questionnaireId)
+                    : answers;
             }
             const html = formHelper.getSectionHtml(
                 response.body,

--- a/questionnaire/routes.js
+++ b/questionnaire/routes.js
@@ -50,10 +50,10 @@ router
                 response.body.data[0].attributes &&
                 response.body.data[0].attributes.sectionId
             ) {
-                const isSummary = formHelper.checkIsSummary(
+                const isSummaryPage = formHelper.checkIsSummaryContext(
                     response.body.data[0].attributes.sectionId
                 );
-                answers = isSummary
+                answers = isSummaryPage
                     ? await qService.getAnswers(req.cicaSession.questionnaireId)
                     : answers;
             }

--- a/test/form-helper.test.js
+++ b/test/form-helper.test.js
@@ -361,18 +361,36 @@ describe('form-helper functions', () => {
     });
 
     describe('Check is summary', () => {
-        it('Should return true if a section has `isSummary: true` in the UISchema', () => {
-            const sectionName = 'p-applicant-declaration';
+        it('Should return true if a section has `pageContext: summary` in the UISchema', () => {
+            const sectionName = 'p--check-your-answers';
 
             const actual = formHelper.checkIsSummary(sectionName);
 
             expect(actual).toEqual(true);
         });
 
-        it('Should return false if a section has no `isSummary` value in the UISchema', () => {
-            const sectionName = 'p--check-your-answers';
+        it('Should return false if a section has no `pageContext` value in the UISchema', () => {
+            const sectionName = 'p--confirmation';
 
             const actual = formHelper.checkIsSummary(sectionName);
+
+            expect(actual).toEqual(false);
+        });
+    });
+
+    describe('Check is submission', () => {
+        it('Should return true if a section has `pageContext: submission` in the UISchema', () => {
+            const sectionName = 'p-applicant-declaration';
+
+            const actual = formHelper.checkIsSubmission(sectionName);
+
+            expect(actual).toEqual(true);
+        });
+
+        it('Should return false if a section has no `pageContext` value in the UISchema', () => {
+            const sectionName = 'p--confirmation';
+
+            const actual = formHelper.checkIsSubmission(sectionName);
 
             expect(actual).toEqual(false);
         });

--- a/test/form-helper.test.js
+++ b/test/form-helper.test.js
@@ -364,7 +364,7 @@ describe('form-helper functions', () => {
         it('Should return true if a section has `pageContext: summary` in the UISchema', () => {
             const sectionName = 'p--check-your-answers';
 
-            const actual = formHelper.checkIsSummary(sectionName);
+            const actual = formHelper.checkIsSummaryContext(sectionName);
 
             expect(actual).toEqual(true);
         });
@@ -372,7 +372,7 @@ describe('form-helper functions', () => {
         it('Should return false if a section has no `pageContext` value in the UISchema', () => {
             const sectionName = 'p--confirmation';
 
-            const actual = formHelper.checkIsSummary(sectionName);
+            const actual = formHelper.checkIsSummaryContext(sectionName);
 
             expect(actual).toEqual(false);
         });
@@ -382,7 +382,7 @@ describe('form-helper functions', () => {
         it('Should return true if a section has `pageContext: submission` in the UISchema', () => {
             const sectionName = 'p-applicant-declaration';
 
-            const actual = formHelper.checkIsSubmission(sectionName);
+            const actual = formHelper.checkIsSubmissionContext(sectionName);
 
             expect(actual).toEqual(true);
         });
@@ -390,7 +390,7 @@ describe('form-helper functions', () => {
         it('Should return false if a section has no `pageContext` value in the UISchema', () => {
             const sectionName = 'p--confirmation';
 
-            const actual = formHelper.checkIsSubmission(sectionName);
+            const actual = formHelper.checkIsSubmissionContext(sectionName);
 
             expect(actual).toEqual(false);
         });

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -278,7 +278,7 @@ describe('Data capture service endpoints', () => {
                             addPrefix: () => prefixedSection,
                             getSectionHtml: () => getSectionHtmlValid,
                             removeSectionIdPrefix: () => initial,
-                            checkIsSummary: () => false
+                            checkIsSummaryContext: () => false
                         }));
                         // eslint-disable-next-line global-require
                         app = require('../app');

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -277,7 +277,8 @@ describe('Data capture service endpoints', () => {
                         jest.doMock('../questionnaire/form-helper', () => ({
                             addPrefix: () => prefixedSection,
                             getSectionHtml: () => getSectionHtmlValid,
-                            removeSectionIdPrefix: () => initial
+                            removeSectionIdPrefix: () => initial,
+                            checkIsSummary: () => false
                         }));
                         // eslint-disable-next-line global-require
                         app = require('../app');


### PR DESCRIPTION
This PR prevents CW from checking the schema metadata to identify if a particular page is a summary. This is now handled in the UISchema.