### PR TITLE
Add app version header

### DIFF
--- a/app.js
+++ b/app.js
@@ -35,6 +35,8 @@ nunjucks
 
 app.use((req, res, next) => {
     res.locals.nonce = nanoid();
+    // https://stackoverflow.com/a/22339262/2952356
+    // `process.env.npm_package_version` only works if you use npm start to run the app.
     res.set('Application-Version', process.env.npm_package_version);
     next();
 });

--- a/app.js
+++ b/app.js
@@ -35,7 +35,7 @@ nunjucks
 
 app.use((req, res, next) => {
     res.locals.nonce = nanoid();
-
+    res.set('Application-Version', process.env.npm_package_version);
     next();
 });
 


### PR DESCRIPTION
Adds a custom `Application-Version` response header. The value is taken indirectly (via the auto-created environment variables) from the `package.json`