### PR TITLE
Change pref cookie sameSite atrribute to 'lax'

### DIFF
--- a/src/modules/cookie-preference/index.js
+++ b/src/modules/cookie-preference/index.js
@@ -4,7 +4,7 @@ function createCookiePreference(cookieName, allowedPreferences) {
     const cookieConfig = {
         path: '/',
         expires: 365,
-        samesite: 'strict'
+        samesite: 'lax'
     };
 
     function get(preferenceName) {


### PR DESCRIPTION
Fixes cookie banner reappearing (after initial cookie acceptance) in FF if navigating from an external domain.

Tested in:
* FF
* Chrome
* Edge
* IE