### PR TITLE
Update q-transformer to v1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "morgan": "~1.9.0",
         "nanoid": "^2.1.10",
         "nunjucks": "^3.2.1",
-        "q-transformer": "github:CriminalInjuriesCompensationAuthority/q-transformer.git#v1.0.0"
+        "q-transformer": "github:CriminalInjuriesCompensationAuthority/q-transformer.git#v1.0.1"
     },
     "devDependencies": {
         "@babel/core": "^7.7.4",


### PR DESCRIPTION
This PR bumps the version of q-transformer to v1.0.1, which will fix the issue around headings appearing on the CYA page when they shouldn't.

Manual testing has been carried out, all automated tests, lint and build were successful.