### PR TITLE
Add triage to cya

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "cica-web",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cica-web",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "private": true,
     "scripts": {
         "start:dev": "nodemon -L --inspect=0.0.0.0:9229 -e .css,.js,.json,.njk --ignore public/dist/ --exec npm run buildRun:dev",

--- a/questionnaire/questionnaireUISchema.js
+++ b/questionnaire/questionnaireUISchema.js
@@ -157,6 +157,10 @@ module.exports = {
                             {
                                 title: 'Your injuries',
                                 questions: {
+                                    'p-applicant-are-you-claiming-for-physical-injuries':
+                                        'Are you claiming for physical injuries?',
+                                    'p-applicant-are-you-claiming-for-payments':
+                                        'Are you claiming for a sexually transmitted infection (STI), pregnancy, or loss of a pregnancy?',
                                     'p-applicant-do-you-have-disabling-mental-injury':
                                         'Do you have a disabling mental injury?',
                                     'p-applicant-mental-injury-duration':
@@ -177,6 +181,15 @@ module.exports = {
                                     'p-applicant-have-you-seen-a-gp':
                                         'Have you seen a GP about your injuries?',
                                     'p-gp-enter-your-address': "What is your GP's address?"
+                                }
+                            },
+                            {
+                                title: 'Money',
+                                questions: {
+                                    'p-applicant-are-you-claiming-for-loe':
+                                        'Are you claiming for loss of earnings?',
+                                    'p-applicant-are-you-claiming-for-expenses':
+                                        'Are you claiming for expenses as a result of your injuries?'
                                 }
                             },
                             {


### PR DESCRIPTION
The PR changes the structure of the CYA page to include triage questions that were previously missing.

It also increases the version to v1.3.1

All automated tests passed and has been manually tested.