### PR TITLE
Add 'self' to CSP connectSrc

### DIFF
--- a/app.js
+++ b/app.js
@@ -60,7 +60,7 @@ app.use(
                 imgSrc: ["'self'", 'data:', 'www.google-analytics.com'],
                 objectSrc: ["'none'"],
                 frameSrc: ['*.ccng.bt.com'],
-                connectSrc: ['www.google-analytics.com']
+                connectSrc: ["'self'", 'www.google-analytics.com']
             }
         },
         hsts: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "cica-web",
-    "version": "1.5.1",
+    "version": "1.5.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cica-web",
-    "version": "1.5.1",
+    "version": "1.5.2",
     "private": true,
     "scripts": {
         "start:dev": "nodemon -L --inspect=0.0.0.0:9229 -e .css,.js,.json,.njk --ignore public/dist/ --ignore src/js/scripts.babel.generated.js --exec npm run buildRun:dev",


### PR DESCRIPTION
allows the web app to request a page from itself. Fixes bug where it was not able to request `/something` and resulted in a status of `(blocked:csp)`