### PR TITLE
Add no-cache headers to CYA page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "cica-web",
-    "version": "1.6.2",
+    "version": "1.7.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cica-web",
-    "version": "1.6.2",
+    "version": "1.7.0",
     "private": true,
     "scripts": {
         "start:dev": "nodemon -L --inspect=0.0.0.0:9229 -e .css,.js,.json,.njk --ignore public/dist/ --ignore src/js/scripts.babel.generated.js --exec npm run buildRun:dev",

--- a/page/404.njk
+++ b/page/404.njk
@@ -7,6 +7,8 @@
     <h1 class="govuk-heading-xl">Page not found</h1>
     <p class="govuk-body">If you typed the web address, check it is correct.</p>
     <p class="govuk-body">If you pasted the web address, check you copied the entire address.</p>
-    <p class="govuk-body">If the web address is correct or you selected a link or button, you can contact us for help with your application</p>
+    <p class="govuk-body">If you want to navigate back a page, use the 'back' link on the page</p>
+    <p class="govuk-body">To continue, <a href="\apply">complete your application</a> and check your answers</p>
+    <p class="govuk-body">If the web address is correct or this error persists, you can contact us for help with your application</p>
     {% include "contact.njk" %}
 {% endblock %}

--- a/questionnaire/routes.js
+++ b/questionnaire/routes.js
@@ -53,9 +53,15 @@ router
                 const isSummaryPage =
                     formHelper.getSectionContext(response.body.data[0].attributes.sectionId) ===
                     'summary';
-                answers = isSummaryPage
-                    ? await qService.getAnswers(req.cicaSession.questionnaireId)
-                    : answers;
+
+                if (isSummaryPage) {
+                    answers = await qService.getAnswers(req.cicaSession.questionnaireId);
+                    res.set({
+                        'Cache-Control': 'private, no-cache, no-store, must-revalidate',
+                        Expires: '-1',
+                        Pragma: 'no-cache'
+                    });
+                }
             }
             const html = formHelper.getSectionHtml(
                 response.body,


### PR DESCRIPTION
This commit adds to the header package for summary pages only.
The new headers will stop the page being cached so out of date information
will not be displayed here.

The commit also adds updated content to the default 404 page which helps
the user recover and continue their application.

Finally, this PR includes a version bump to v1.7.0

Test passes
Lint Passes
Manual testing passes