### PR TITLE
Add uiSchema test for unique keys

### DIFF
--- a/questionnaire/questionnaireUISchema.js
+++ b/questionnaire/questionnaireUISchema.js
@@ -232,10 +232,6 @@ module.exports = {
                                         'Do you have a disabling mental injury?',
                                     'p-applicant-mental-injury-duration':
                                         'Has your mental injury lasted 6 weeks or more?',
-                                    'p-applicant-select-treatments':
-                                        'What mental health treatments have you had?',
-                                    'p-applicant-has-your-treatment-finished-dmi':
-                                        'Have you finished your treatment?',
                                     'p-applicant-affect-on-daily-life-dmi':
                                         'Briefly say how the crime has affected your daily life'
                                 }

--- a/test/uiSchema.test.js
+++ b/test/uiSchema.test.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const uiSchema = require('../questionnaire/questionnaireUISchema');
+
+const findDuplicates = arr => {
+    const sortedArr = arr.slice().sort();
+    const results = [];
+    sortedArr.forEach((item, index) => {
+        if (sortedArr[index + 1] === item) {
+            results.push(item);
+        }
+    });
+    return results;
+};
+
+describe('UISchema', () => {
+    describe('Check your answers', () => {
+        const pageProperties =
+            uiSchema['p--check-your-answers'].options.properties['p-check-your-answers'].options;
+        describe('summaryStructure', () => {
+            const structure = pageProperties.summaryStructure;
+            describe('Question IDs', () => {
+                it('Should appear only once in the structure', () => {
+                    let keyArr = [];
+                    structure.forEach(section => {
+                        keyArr = [...keyArr, ...Object.keys(section.questions)];
+                    });
+
+                    const output = findDuplicates(keyArr);
+
+                    expect(output).toEqual([]);
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
This PR removes duplicate questions from the CYA structure.

It also adds a test which checks for duplicate questions, and fails if they keys in the structure are not unique.

Automated tests pass
Lint passes
Manual test passes