### PR TITLE
Add date input maxlength support

### DIFF
--- a/components/cica/modal/template.njk
+++ b/components/cica/modal/template.njk
@@ -18,7 +18,7 @@
                 focusable="false"
                 class="govuk-modal__header-image"
                 xmlns="http://www.w3.org/2000/svg"
-                viewbox="0 0 132 97"
+                viewBox="0 0 132 97"
                 height="30"
                 width="36"
                 >

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "cica-web",
-    "version": "1.7.2",
+    "version": "1.7.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11332,8 +11332,8 @@
             }
         },
         "q-transformer": {
-            "version": "github:CriminalInjuriesCompensationAuthority/q-transformer#00c5f8a8cc4ad6b5401f8bcdcc8e1a92d760ed12",
-            "from": "github:CriminalInjuriesCompensationAuthority/q-transformer#v1.2.0",
+            "version": "github:CriminalInjuriesCompensationAuthority/q-transformer#d163bda1dfdc06c83d0e83ce1781789722d66720",
+            "from": "github:CriminalInjuriesCompensationAuthority/q-transformer#v1.2.1",
             "requires": {
                 "lodash.merge": "^4.6.2",
                 "moment": "^2.24.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7207,9 +7207,9 @@
             }
         },
         "govuk-frontend": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.4.0.tgz",
-            "integrity": "sha512-rmYPtcCtWgz92QBejYwOnfSxbPGYfvSruLwB4CBk/yJtySHRY0whG1e2/iFRRSj0pMx1Bu+zh/IqCTo+84hbFw=="
+            "version": "3.10.2",
+            "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.10.2.tgz",
+            "integrity": "sha512-MpMymgLsKoMw40MggZ0XLCAj1FY5N2s8Pf3aQR+k0cZOsegjLsnejxNfEB9qEl9jcma2fiiVcvsEZ+Ipo+Oo2g=="
         },
         "graceful-fs": {
             "version": "4.2.3",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "morgan": "~1.9.0",
         "nanoid": "^2.1.10",
         "nunjucks": "^3.2.1",
-        "q-transformer": "github:CriminalInjuriesCompensationAuthority/q-transformer#v1.2.0"
+        "q-transformer": "github:CriminalInjuriesCompensationAuthority/q-transformer#v1.2.1"
     },
     "devDependencies": {
         "@babel/cli": "^7.12.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cica-web",
-    "version": "1.7.2",
+    "version": "1.7.3",
     "private": true,
     "scripts": {
         "start:dev": "nodemon -L --inspect=0.0.0.0:9229 -e .css,.js,.json,.njk --ignore public/dist/ --ignore src/js/scripts.babel.generated.js --exec npm run buildRun:dev",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "debug": "~2.6.9",
         "express": "~4.16.0",
         "got": "^9.6.0",
-        "govuk-frontend": "3.4.0",
+        "govuk-frontend": "^3.10.2",
         "helmet": "^3.15.0",
         "js-cookie": "^2.2.1",
         "lodash.merge": "^4.6.1",

--- a/test/test-fixtures/transformations/resolved html/p-applicant-british-citizen-or-eu-national.js
+++ b/test/test-fixtures/transformations/resolved html/p-applicant-british-citizen-or-eu-national.js
@@ -3,15 +3,15 @@
 const html = `<!DOCTYPE html>
 <html lang="en" class="govuk-template ">
   <head>
-    <meta charset="utf-8" />
+    <meta charset="utf-8">
     <title>Are you a British citizen or EU national? - Claim criminal injuries compensation - GOV.UK</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-    <meta name="theme-color" content="#0b0c0c" />
+    <meta name="theme-color" content="#0b0c0c">
 
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
 
-      <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="/assets/images/favicon.ico" type="image/x-icon" />
+      <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="/assets/images/favicon.ico" type="image/x-icon">
       <link rel="mask-icon" href="/assets/images/govuk-mask-icon.svg" color="#0b0c0c">
       <link rel="apple-touch-icon" sizes="180x180" href="/assets/images/govuk-apple-touch-icon-180x180.png">
       <link rel="apple-touch-icon" sizes="167x167" href="/assets/images/govuk-apple-touch-icon-167x167.png">
@@ -85,11 +85,11 @@ const html = `<!DOCTYPE html>
         <span class="govuk-header__logotype">
 
           <svg
-            role="presentation"
+            aria-hidden="true"
             focusable="false"
             class="govuk-header__logotype-crown"
             xmlns="http://www.w3.org/2000/svg"
-            viewbox="0 0 132 97"
+            viewBox="0 0 132 97"
             height="30"
             width="36"
           >
@@ -273,11 +273,11 @@ const html = `<!DOCTYPE html>
 
 
         <svg
-          role="presentation"
+          aria-hidden="true"
           focusable="false"
           class="govuk-footer__licence-logo"
           xmlns="http://www.w3.org/2000/svg"
-          viewbox="0 0 483.2 195.7"
+          viewBox="0 0 483.2 195.7"
           height="17"
           width="41"
         >
@@ -323,7 +323,7 @@ const html = `<!DOCTYPE html>
                 focusable="false"
                 class="govuk-modal__header-image"
                 xmlns="http://www.w3.org/2000/svg"
-                viewbox="0 0 132 97"
+                viewBox="0 0 132 97"
                 height="30"
                 width="36"
                 >
@@ -398,7 +398,7 @@ const html = `<!DOCTYPE html>
                 focusable="false"
                 class="govuk-modal__header-image"
                 xmlns="http://www.w3.org/2000/svg"
-                viewbox="0 0 132 97"
+                viewBox="0 0 132 97"
                 height="30"
                 width="36"
                 >
@@ -471,7 +471,7 @@ const html = `<!DOCTYPE html>
                 focusable="false"
                 class="govuk-modal__header-image"
                 xmlns="http://www.w3.org/2000/svg"
-                viewbox="0 0 132 97"
+                viewBox="0 0 132 97"
                 height="30"
                 width="36"
                 >


### PR DESCRIPTION
bump `govuk-frontend` from `3.4` to `3.10.2` - date inputs are now `text` (previously 'number`) allowing the use of the `maxlength` attribute to limit user input for each `day`, `month`, and `year` inputs.