### PR TITLE
Remove form autocomplete

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "cica-web",
-    "version": "1.7.5",
+    "version": "1.7.6",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11332,8 +11332,8 @@
             }
         },
         "q-transformer": {
-            "version": "github:CriminalInjuriesCompensationAuthority/q-transformer#1b3accd75aad2f2a8a73087ed0afdbae4816817a",
-            "from": "github:CriminalInjuriesCompensationAuthority/q-transformer#v1.3.0",
+            "version": "github:CriminalInjuriesCompensationAuthority/q-transformer#87aa2d86f55287ef915eab1381979400117325d7",
+            "from": "github:CriminalInjuriesCompensationAuthority/q-transformer#v1.3.1",
             "requires": {
                 "lodash.merge": "^4.6.2",
                 "moment": "^2.24.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "morgan": "~1.9.0",
         "nanoid": "^2.1.10",
         "nunjucks": "^3.2.1",
-        "q-transformer": "github:CriminalInjuriesCompensationAuthority/q-transformer#v1.3.0"
+        "q-transformer": "github:CriminalInjuriesCompensationAuthority/q-transformer#v1.3.1"
     },
     "devDependencies": {
         "@babel/cli": "^7.12.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cica-web",
-    "version": "1.7.5",
+    "version": "1.7.6",
     "private": true,
     "scripts": {
         "start:dev": "nodemon -L --inspect=0.0.0.0:9229 -e .css,.js,.json,.njk --ignore public/dist/ --ignore src/js/scripts.babel.generated.js --exec npm run buildRun:dev",

--- a/questionnaire/form-helper.js
+++ b/questionnaire/form-helper.js
@@ -66,7 +66,7 @@ function renderSection({
                 {% endif %}
             {% endblock %}
             {% block innerContent %}
-                <form method="post" {%- if ${isSubmissionPage} %} action="/apply/submission/confirm"{% endif %} novalidate>
+                <form method="post" {%- if ${isSubmissionPage} %} action="/apply/submission/confirm"{% endif %} novalidate autocomplete="off">
                     {% from "button/macro.njk" import govukButton %}
                         ${transformation.content}
                     {% if ${showButton} %}

--- a/questionnaire/questionnaireUISchema.js
+++ b/questionnaire/questionnaireUISchema.js
@@ -69,17 +69,6 @@ module.exports = {
             ]
         }
     },
-    'p-applicant-enter-your-date-of-birth': {
-        options: {
-            properties: {
-                'q-applicant-enter-your-date-of-birth': {
-                    options: {
-                        autoComplete: 'bday'
-                    }
-                }
-            }
-        }
-    },
     'p--check-your-answers': {
         options: {
             pageContext: 'summary',
@@ -660,32 +649,38 @@ module.exports = {
                 'q-applicant-building-and-street': {
                     options: {
                         macroOptions: {
-                            classes: ''
-                        },
-                        autoComplete: 'address-line1'
+                            classes: '',
+                            autocomplete: 'address-line1'
+                        }
                     }
                 },
                 'q-applicant-building-and-street-2': {
                     options: {
                         macroOptions: {
-                            classes: ''
-                        },
-                        autoComplete: 'address-line2'
+                            classes: '',
+                            autocomplete: 'address-line2'
+                        }
                     }
                 },
                 'q-applicant-town-or-city': {
                     options: {
-                        autoComplete: 'address-level2'
+                        macroOptions: {
+                            autocomplete: 'address-level2'
+                        }
                     }
                 },
                 'q-applicant-county': {
                     options: {
-                        autoComplete: 'address-level1'
+                        macroOptions: {
+                            autocomplete: 'address-level1'
+                        }
                     }
                 },
                 'q-applicant-postcode': {
                     options: {
-                        autoComplete: 'postal-code'
+                        macroOptions: {
+                            autocomplete: 'postal-code'
+                        }
                     }
                 }
             },
@@ -709,17 +704,23 @@ module.exports = {
             properties: {
                 'q-applicant-title': {
                     options: {
-                        autoComplete: 'honorific-prefix'
+                        macroOptions: {
+                            autocomplete: 'honorific-prefix'
+                        }
                     }
                 },
                 'q-applicant-first-name': {
                     options: {
-                        autoComplete: 'given-name'
+                        macroOptions: {
+                            autocomplete: 'given-name'
+                        }
                     }
                 },
                 'q-applicant-last-name': {
                     options: {
-                        autoComplete: 'family-name'
+                        macroOptions: {
+                            autocomplete: 'family-name'
+                        }
                     }
                 }
             }
@@ -822,8 +823,8 @@ module.exports = {
             properties: {
                 'q-applicant-enter-your-email-address': {
                     options: {
-                        autocomplete: 'email',
-                        attributes: {
+                        macroOptions: {
+                            autocomplete: 'email',
                             spellcheck: 'false'
                         }
                     }
@@ -836,7 +837,9 @@ module.exports = {
             properties: {
                 'q-applicant-enter-your-telephone-number': {
                     options: {
-                        autoComplete: 'tel'
+                        macroOptions: {
+                            autocomplete: 'tel'
+                        }
                     }
                 }
             }
@@ -875,14 +878,16 @@ module.exports = {
                 'q-applicant-enter-your-email-address': {
                     options: {
                         macroOptions: {
-                            classes: 'govuk-input--width-20'
+                            classes: 'govuk-input--width-20',
+                            autocomplete: 'email'
                         }
                     }
                 },
                 'q-applicant-enter-your-telephone-number': {
                     options: {
                         macroOptions: {
-                            classes: 'govuk-input--width-20'
+                            classes: 'govuk-input--width-20',
+                            autocomplete: 'tel'
                         }
                     }
                 }

--- a/test/test-fixtures/transformations/resolved html/p-applicant-british-citizen-or-eu-national.js
+++ b/test/test-fixtures/transformations/resolved html/p-applicant-british-citizen-or-eu-national.js
@@ -152,7 +152,7 @@ const html = `<!DOCTYPE html>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
 
-                <form method="post" novalidate>
+                <form method="post" novalidate autocomplete="off">
 
 
 


### PR DESCRIPTION
* add `autocomplete="off"` to form element to disable all browser autocompletion on form input elements. Overridden by use of the `autocomplete` attribute on specific elements.
* remove `autocomplete` definition for `date-of-birth` schema in the UISchema.
* move all `autocomplete` definitions within the UISchema in to the `macroOptions`
* fix bug in email definition in UISchema.