### PR TITLE
Livechat holiday updates

### DIFF
--- a/index/bank-holidays.json
+++ b/index/bank-holidays.json
@@ -1,0 +1,134 @@
+{
+    "division": "scotland",
+    "events": [
+        {"title": "2nd January", "date": "2017-01-02", "notes": "", "bunting": true},
+        {
+            "title": "New Year’s Day",
+            "date": "2017-01-03",
+            "notes": "Substitute day",
+            "bunting": true
+        },
+        {"title": "Good Friday", "date": "2017-04-14", "notes": "", "bunting": false},
+        {"title": "Early May bank holiday", "date": "2017-05-01", "notes": "", "bunting": true},
+        {"title": "Spring bank holiday", "date": "2017-05-29", "notes": "", "bunting": true},
+        {"title": "Summer bank holiday", "date": "2017-08-07", "notes": "", "bunting": true},
+        {"title": "St Andrew’s Day", "date": "2017-11-30", "notes": "", "bunting": true},
+        {"title": "Christmas Day", "date": "2017-12-25", "notes": "", "bunting": true},
+        {"title": "Boxing Day", "date": "2017-12-26", "notes": "", "bunting": true},
+        {"title": "New Year’s Day", "date": "2018-01-01", "notes": "", "bunting": true},
+        {"title": "2nd January", "date": "2018-01-02", "notes": "", "bunting": true},
+        {"title": "Good Friday", "date": "2018-03-30", "notes": "", "bunting": false},
+        {"title": "Early May bank holiday", "date": "2018-05-07", "notes": "", "bunting": true},
+        {"title": "Spring bank holiday", "date": "2018-05-28", "notes": "", "bunting": true},
+        {"title": "Summer bank holiday", "date": "2018-08-06", "notes": "", "bunting": true},
+        {"title": "St Andrew’s Day", "date": "2018-11-30", "notes": "", "bunting": true},
+        {"title": "Christmas Day", "date": "2018-12-25", "notes": "", "bunting": true},
+        {"title": "Boxing Day", "date": "2018-12-26", "notes": "", "bunting": true},
+        {"title": "New Year’s Day", "date": "2019-01-01", "notes": "", "bunting": true},
+        {"title": "2nd January", "date": "2019-01-02", "notes": "", "bunting": true},
+        {"title": "Good Friday", "date": "2019-04-19", "notes": "", "bunting": false},
+        {"title": "Early May bank holiday", "date": "2019-05-06", "notes": "", "bunting": true},
+        {"title": "Spring bank holiday", "date": "2019-05-27", "notes": "", "bunting": true},
+        {"title": "Summer bank holiday", "date": "2019-08-05", "notes": "", "bunting": true},
+        {
+            "title": "St Andrew’s Day",
+            "date": "2019-12-02",
+            "notes": "Substitute day",
+            "bunting": true
+        },
+        {"title": "Christmas Day", "date": "2019-12-25", "notes": "", "bunting": true},
+        {"title": "Boxing Day", "date": "2019-12-26", "notes": "", "bunting": true},
+        {"title": "New Year’s Day", "date": "2020-01-01", "notes": "", "bunting": true},
+        {"title": "2nd January", "date": "2020-01-02", "notes": "", "bunting": true},
+        {"title": "Good Friday", "date": "2020-04-10", "notes": "", "bunting": false},
+        {
+            "title": "Early May bank holiday (VE day)",
+            "date": "2020-05-08",
+            "notes": "",
+            "bunting": true
+        },
+        {"title": "Spring bank holiday", "date": "2020-05-25", "notes": "", "bunting": true},
+        {"title": "Summer bank holiday", "date": "2020-08-03", "notes": "", "bunting": true},
+        {"title": "St Andrew’s Day", "date": "2020-11-30", "notes": "", "bunting": true},
+        {"title": "Christmas Day", "date": "2020-12-25", "notes": "", "bunting": true},
+        {
+            "title": "Boxing Day",
+            "date": "2020-12-28",
+            "notes": "Substitute day",
+            "bunting": true
+        },
+        {"title": "New Year’s Day", "date": "2021-01-01", "notes": "", "bunting": true},
+        {
+            "title": "2nd January",
+            "date": "2021-01-04",
+            "notes": "Substitute day",
+            "bunting": true
+        },
+        {"title": "Good Friday", "date": "2021-04-02", "notes": "", "bunting": false},
+        {"title": "Early May bank holiday", "date": "2021-05-03", "notes": "", "bunting": true},
+        {"title": "Spring bank holiday", "date": "2021-05-31", "notes": "", "bunting": true},
+        {"title": "Summer bank holiday", "date": "2021-08-02", "notes": "", "bunting": true},
+        {"title": "St Andrew’s Day", "date": "2021-11-30", "notes": "", "bunting": true},
+        {
+            "title": "Christmas Day",
+            "date": "2021-12-27",
+            "notes": "Substitute day",
+            "bunting": true
+        },
+        {
+            "title": "Boxing Day",
+            "date": "2021-12-28",
+            "notes": "Substitute day",
+            "bunting": true
+        },
+        {
+            "title": "New Year’s Day",
+            "date": "2022-01-03",
+            "notes": "Substitute day",
+            "bunting": true
+        },
+        {
+            "title": "2nd January",
+            "date": "2022-01-04",
+            "notes": "Substitute day",
+            "bunting": true
+        },
+        {"title": "Good Friday", "date": "2022-04-15", "notes": "", "bunting": false},
+        {"title": "Early May bank holiday", "date": "2022-05-02", "notes": "", "bunting": true},
+        {"title": "Spring bank holiday", "date": "2022-06-02", "notes": "", "bunting": true},
+        {
+            "title": "Platinum Jubilee bank holiday",
+            "date": "2022-06-03",
+            "notes": "",
+            "bunting": true
+        },
+        {"title": "Summer bank holiday", "date": "2022-08-01", "notes": "", "bunting": true},
+        {"title": "St Andrew’s Day", "date": "2022-11-30", "notes": "", "bunting": true},
+        {"title": "Boxing Day", "date": "2022-12-26", "notes": "", "bunting": true},
+        {
+            "title": "Christmas Day",
+            "date": "2022-12-27",
+            "notes": "Substitute day",
+            "bunting": true
+        },
+        {
+            "title": "New Year’s Day",
+            "date": "2023-01-02",
+            "notes": "Substitute day",
+            "bunting": true
+        },
+        {
+            "title": "2nd January",
+            "date": "2023-01-03",
+            "notes": "Substitute day",
+            "bunting": true
+        },
+        {"title": "Good Friday", "date": "2023-04-07", "notes": "", "bunting": false},
+        {"title": "Early May bank holiday", "date": "2023-05-01", "notes": "", "bunting": true},
+        {"title": "Spring bank holiday", "date": "2023-05-29", "notes": "", "bunting": true},
+        {"title": "Summer bank holiday", "date": "2023-08-07", "notes": "", "bunting": true},
+        {"title": "St Andrew’s Day", "date": "2023-11-30", "notes": "", "bunting": true},
+        {"title": "Christmas Day", "date": "2023-12-25", "notes": "", "bunting": true},
+        {"title": "Boxing Day", "date": "2023-12-26", "notes": "", "bunting": true}
+    ]
+}

--- a/index/liveChatHelper.js
+++ b/index/liveChatHelper.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const moment = require('moment-timezone');
+const bankHolidays = require('./bank-holidays.json');
 
 function createLiveChatHelper() {
     function isBetween(dateInput, dateStart, dateEnd) {
@@ -28,7 +29,14 @@ function createLiveChatHelper() {
         return stringList.split(',');
     }
 
+    function isBankHoliday() {
+        return bankHolidays.events.some(x => moment(x.date).isSame(new Date(), 'day'));
+    }
+
     function isLiveChatActive(startTimes, endTimes) {
+        if (isBankHoliday()) {
+            return false;
+        }
         const startTimesArray = getOperationalTimesOfDayFromString(startTimes);
         const endTimesArray = getOperationalTimesOfDayFromString(endTimes);
         const today = new Date();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "cica-web",
-    "version": "2.3.3",
+    "version": "2.4.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cica-web",
-    "version": "2.3.3",
+    "version": "2.4.0",
     "private": true,
     "scripts": {
         "start:dev": "nodemon -L --inspect=0.0.0.0:9229 -e .css,.js,.json,.njk --ignore public/dist/ --ignore src/js/scripts.babel.generated.js --exec npm run buildRun:dev",

--- a/test/livechat-helper.test.js
+++ b/test/livechat-helper.test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const moment = require('moment-timezone');
 const createLiveChatHelper = require('../index/liveChatHelper');
 
 describe('Live Chat Helper', () => {
@@ -36,6 +37,29 @@ describe('Live Chat Helper', () => {
             );
             jest.useRealTimers();
             expect(result).toBe(false);
+        });
+        describe('bank holidays', () => {
+            it('should return false for being a bank holiday', () => {
+                jest.useFakeTimers('modern');
+                jest.setSystemTime(new Date(2018, 11, 25, 4, 0, 48)); // Tue Dec 25 2018 04:00:48 GMT+0000 (Greenwich Mean Time)
+                const liveChatHelper = createLiveChatHelper();
+                const result = liveChatHelper.isLiveChatActive(
+                    process.env.CW_LIVECHAT_START_TIMES,
+                    process.env.CW_LIVECHAT_END_TIMES
+                );
+                jest.useRealTimers();
+                expect(result).toBe(false);
+            });
+
+            it('should have a list of future bank holidays', () => {
+                // eslint-disable-next-line global-require
+                const bankHolidays = require('../index/bank-holidays.json');
+                const today = new Date();
+                const futureBankHolidays = bankHolidays.events.filter(x =>
+                    moment(x.date).isAfter(today, 'day')
+                );
+                expect(futureBankHolidays.length).toBeGreaterThan(4);
+            });
         });
     });
 });


### PR DESCRIPTION
Adds Bank holidays to the Live Chat opening and closing times. It now automatically enables and disables the Live Chat for these dates.

proposed version: `2.4.0` - Minor bump due to additional functionality being added in a backwards-compatible manor.