### PR TITLE
Feature/improve livechat lifecycle worflow

### DIFF
--- a/app.js
+++ b/app.js
@@ -36,7 +36,17 @@ nunjucks
     .addGlobal('CW_GA_TRACKING_ID', process.env.CW_GA_TRACKING_ID)
     .addGlobal('CW_URL', process.env.CW_URL)
     .addGlobal('CW_SESSION_DURATION', process.env.CW_SESSION_DURATION)
-    .addGlobal('CW_LIVECHAT_CHAT_ID', process.env.CW_LIVECHAT_CHAT_ID);
+    .addGlobal('CW_LIVECHAT_CHAT_ID', process.env.CW_LIVECHAT_CHAT_ID)
+    .addGlobal(
+        'CW_LIVECHAT_MAINTENANCE_MESSAGE',
+        !process.env?.CW_LIVECHAT_MAINTENANCE_MESSAGE?.length
+            ? 'maintenance message not set'
+            : process.env.CW_LIVECHAT_MAINTENANCE_MESSAGE
+    )
+    .addGlobal(
+        'CW_LIVECHAT_MAINTENANCE_MESSAGE_ENABLED',
+        process.env.CW_LIVECHAT_MAINTENANCE_MESSAGE_ENABLED === 'true'
+    );
 
 app.use((req, res, next) => {
     res.locals.nonce = nanoid();

--- a/index/chat-withdrawn.njk
+++ b/index/chat-withdrawn.njk
@@ -21,8 +21,10 @@
 
     {% endif %}
 
-    {% include "table-opening-times.njk" %}
+    <p class="govuk-body">Our live chat service has been withdrawn.</p>
 
-    <p class="govuk-body">Email <a href="mailto:info@cica.gov.uk" class="govuk-link">info@cica.gov.uk</a> if you need to contact us.</p>
+    <h2 class="govuk-heading-l">Other ways of contacting CICA</h2>
+
+    {% include "contact.njk" %}
 
 {% endblock %}

--- a/index/routes.js
+++ b/index/routes.js
@@ -26,8 +26,12 @@ router.get('/accessibility-statement', (req, res) => {
 });
 
 router.get('/start-chat', (req, res) => {
+    if (process.env.CW_LIVECHAT_ALIVE !== 'true') {
+        return res.render('chat-withdrawn.njk');
+    }
     const liveChatHelper = createLiveChatHelper();
     if (
+        process.env.CW_LIVECHAT_DISABLED !== 'true' &&
         liveChatHelper.isLiveChatActive(
             process.env.CW_LIVECHAT_START_TIMES,
             process.env.CW_LIVECHAT_END_TIMES
@@ -39,8 +43,12 @@ router.get('/start-chat', (req, res) => {
 });
 
 router.get('/chat', (req, res) => {
+    if (process.env.CW_LIVECHAT_ALIVE !== 'true') {
+        return res.render('chat-withdrawn.njk');
+    }
     const liveChatHelper = createLiveChatHelper();
     if (
+        process.env.CW_LIVECHAT_DISABLED !== 'true' &&
         liveChatHelper.isLiveChatActive(
             process.env.CW_LIVECHAT_START_TIMES,
             process.env.CW_LIVECHAT_END_TIMES

--- a/index/start-chat.njk
+++ b/index/start-chat.njk
@@ -1,12 +1,25 @@
 {% extends "page.njk" %}
 {% from "components/radios/macro.njk" import govukRadios %}
-{% from "components/table/macro.njk" import govukTable %}
+{%- from "moj/components/banner/macro.njk" import mojBanner -%}
 
 {% block pageTitle %}Chat to our customer support team online - {{ super() }}{% endblock %}
 
 {% block innerContent %}
 
     <h1 class="govuk-heading-xl">Chat to us online</h1>
+
+    {% if CW_LIVECHAT_MAINTENANCE_MESSAGE_ENABLED %}
+
+        {% set bannerHtml %}
+            <p class="govuk-body">{{ CW_LIVECHAT_MAINTENANCE_MESSAGE }}</p>
+        {% endset %}
+
+        {{ mojBanner({
+            type: 'information',
+            html: bannerHtml
+        }) }}
+
+    {% endif %}
 
     <p class="govuk-body">You can ask about claiming compensation or discuss your claim.</p>
 

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,11 +1,15 @@
 'use strict';
 
-jest.setTimeout(30000);
+jest.setTimeout(3000);
 jest.testEnvironment = 'node';
 process.env.CW_DCS_JWT = 'A massive string';
 process.env.CW_COOKIE_SECRET = 'Also a huge string';
 process.env.CW_DCS_URL = 'http://docker.for.win.localhost:3100';
+process.env.CW_LIVECHAT_ALIVE = 'true';
+process.env.CW_LIVECHAT_DISABLED = 'false';
+process.env.CW_LIVECHAT_MAINTENANCE_MESSAGE_ENABLED = 'true';
+process.env.CW_LIVECHAT_MAINTENANCE_MESSAGE = 'The live chat service will be unavailable';
 process.env.CW_LIVECHAT_START_TIMES =
-    'false,08:30:00.000,08:30:00.000,10:00:00.000,08:30:00.000,08:30:00.000,false';
+    '00:00:01.000,00:00:01.000,00:00:01.000,00:00:01.000,00:00:01.000,00:00:01.000,00:00:01.000';
 process.env.CW_LIVECHAT_END_TIMES =
-    'false,17:00:00.000,17:00:00.000,17:00:00.000,17:00:00.000,17:00:00.000,false';
+    '23:59:59.000,23:59:59.000,23:59:59.000,23:59:59.000,23:59:59.000,23:59:59.000,23:59:59.000';

--- a/kube_deploy/Dev/deploy.yml
+++ b/kube_deploy/Dev/deploy.yml
@@ -36,10 +36,36 @@ spec:
               value: '900000'
             - name: CW_LIVECHAT_CHAT_ID
               value: ff753a08-883d-453c-bf64-811301587100
+            - name: CW_LIVECHAT_ALIVE
+              valueFrom:
+                secretKeyRef:
+                  name: cica-web-secrets
+                  key: cw_livechat_alive
             - name: CW_LIVECHAT_START_TIMES
-              value: 'false,08:30:00.000,08:30:00.000,08:30:00.000,08:30:00.000,08:30:00.000,false'
+              valueFrom:
+                secretKeyRef:
+                  name: cica-web-secrets
+                  key: cw_livechat_start_times
             - name: CW_LIVECHAT_END_TIMES
-              value: 'false,17:00:00.000,17:00:00.000,15:00:00.000,17:00:00.000,17:00:00.000,false'
+              valueFrom:
+                secretKeyRef:
+                  name: cica-web-secrets
+                  key: cw_livechat_end_times
+            - name: CW_LIVECHAT_DISABLED
+              valueFrom:
+                secretKeyRef:
+                  name: cica-web-secrets
+                  key: cw_livechat_disabled
+            - name: CW_LIVECHAT_MAINTENANCE_MESSAGE_ENABLED
+              valueFrom:
+                secretKeyRef:
+                  name: cica-web-secrets
+                  key: cw_livechat_maintenance_message_enabled
+            - name: CW_LIVECHAT_MAINTENANCE_MESSAGE
+              valueFrom:
+                secretKeyRef:
+                  name: cica-web-secrets
+                  key: cw_livechat_maintenance_message
   selector:
     matchLabels:
       app: webapp-dev

--- a/kube_deploy/Prod/deploy.yml
+++ b/kube_deploy/Prod/deploy.yml
@@ -36,10 +36,36 @@ spec:
               value: '1800000'
             - name: CW_LIVECHAT_CHAT_ID
               value: ff753a08-883d-453c-bf64-811301587100
+            - name: CW_LIVECHAT_ALIVE
+              valueFrom:
+                secretKeyRef:
+                  name: cica-web-secrets
+                  key: cw_livechat_alive
             - name: CW_LIVECHAT_START_TIMES
-              value: 'false,08:30:00.000,08:30:00.000,08:30:00.000,08:30:00.000,08:30:00.000,false'
+              valueFrom:
+                secretKeyRef:
+                  name: cica-web-secrets
+                  key: cw_livechat_start_times
             - name: CW_LIVECHAT_END_TIMES
-              value: 'false,17:00:00.000,17:00:00.000,15:00:00.000,17:00:00.000,17:00:00.000,false'
+              valueFrom:
+                secretKeyRef:
+                  name: cica-web-secrets
+                  key: cw_livechat_end_times
+            - name: CW_LIVECHAT_DISABLED
+              valueFrom:
+                secretKeyRef:
+                  name: cica-web-secrets
+                  key: cw_livechat_disabled
+            - name: CW_LIVECHAT_MAINTENANCE_MESSAGE_ENABLED
+              valueFrom:
+                secretKeyRef:
+                  name: cica-web-secrets
+                  key: cw_livechat_maintenance_message_enabled
+            - name: CW_LIVECHAT_MAINTENANCE_MESSAGE
+              valueFrom:
+                secretKeyRef:
+                  name: cica-web-secrets
+                  key: cw_livechat_maintenance_message
   selector:
     matchLabels:
       app: webapp-prod

--- a/kube_deploy/Uat/deploy.yml
+++ b/kube_deploy/Uat/deploy.yml
@@ -36,10 +36,36 @@ spec:
               value: '1800000'
             - name: CW_LIVECHAT_CHAT_ID
               value: ff753a08-883d-453c-bf64-811301587100
+            - name: CW_LIVECHAT_ALIVE
+              valueFrom:
+                secretKeyRef:
+                  name: cica-web-secrets
+                  key: cw_livechat_alive
             - name: CW_LIVECHAT_START_TIMES
-              value: 'false,08:30:00.000,08:30:00.000,08:30:00.000,08:30:00.000,08:30:00.000,false'
+              valueFrom:
+                secretKeyRef:
+                  name: cica-web-secrets
+                  key: cw_livechat_start_times
             - name: CW_LIVECHAT_END_TIMES
-              value: 'false,17:00:00.000,17:00:00.000,15:00:00.000,17:00:00.000,17:00:00.000,false'
+              valueFrom:
+                secretKeyRef:
+                  name: cica-web-secrets
+                  key: cw_livechat_end_times
+            - name: CW_LIVECHAT_DISABLED
+              valueFrom:
+                secretKeyRef:
+                  name: cica-web-secrets
+                  key: cw_livechat_disabled
+            - name: CW_LIVECHAT_MAINTENANCE_MESSAGE_ENABLED
+              valueFrom:
+                secretKeyRef:
+                  name: cica-web-secrets
+                  key: cw_livechat_maintenance_message_enabled
+            - name: CW_LIVECHAT_MAINTENANCE_MESSAGE
+              valueFrom:
+                secretKeyRef:
+                  name: cica-web-secrets
+                  key: cw_livechat_maintenance_message
   selector:
     matchLabels:
       app: webapp-uat

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "cica-web",
-    "version": "4.0.1",
+    "version": "4.1.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "cica-web",
-            "version": "4.0.1",
+            "version": "4.1.0",
             "license": "MIT",
             "dependencies": {
                 "@ministryofjustice/frontend": "0.0.17-alpha",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cica-web",
-    "version": "4.0.1",
+    "version": "4.1.0",
     "engines": {
         "npm": ">=8.5.2",
         "node": ">=16.0.0"

--- a/test/live-chat.test.js
+++ b/test/live-chat.test.js
@@ -1,0 +1,136 @@
+'use strict';
+
+const request = require('supertest');
+
+let app;
+
+function startApp() {
+    // eslint-disable-next-line global-require
+    app = require('../app');
+}
+
+describe('Live Chat', () => {
+    const OLD_ENV = process.env;
+
+    beforeEach(() => {
+        jest.resetModules();
+        process.env = {...OLD_ENV};
+    });
+
+    afterEach(() => {
+        process.env = OLD_ENV;
+    });
+
+    describe('Withdrawal', () => {
+        it('Should not withdraw the Live Chat service', async () => {
+            process.env.CW_LIVECHAT_ALIVE = 'true';
+            startApp();
+            const response = await request(app).get('/start-chat');
+            const actual = response.res.text;
+            const expected = 'You can ask about claiming compensation or discuss your claim.';
+            expect(actual).toContain(expected);
+        });
+
+        it('Should withdraw the Live Chat service', async () => {
+            process.env.CW_LIVECHAT_ALIVE = 'anythingbutstringtrue';
+            const response = await request(app).get('/start-chat');
+            const actual = response.res.text;
+            const expected = 'Our live chat service has been withdrawn';
+            expect(actual).toContain(expected);
+        });
+    });
+
+    describe('Enabling', () => {
+        it('Should enable the Live Chat service', async () => {
+            process.env.CW_LIVECHAT_DISABLED = 'false';
+            startApp();
+            const response = await request(app).get('/start-chat');
+            const actual = response.res.text;
+            const expected = 'You can ask about claiming compensation or discuss your claim.';
+            expect(actual).toContain(expected);
+        });
+    });
+
+    describe('Disabling', () => {
+        it('Should disable the Live Chat service', async () => {
+            process.env.CW_LIVECHAT_DISABLED = 'true';
+            startApp();
+            const response = await request(app).get('/start-chat');
+            const actual = response.res.text;
+            const expected = 'Sorry, the service is unavailable';
+            expect(actual).toContain(expected);
+        });
+    });
+
+    describe('Maintenance message', () => {
+        it('Should display the maintenance banner', async () => {
+            process.env.CW_LIVECHAT_MAINTENANCE_MESSAGE_ENABLED = 'true';
+            startApp();
+            const response = await request(app).get('/start-chat');
+            const actual = response.res.text;
+            const expected = 'class="moj-banner__message"';
+            expect(actual).toContain(expected);
+        });
+
+        it('Should not display the maintenance banner', async () => {
+            process.env.CW_LIVECHAT_MAINTENANCE_MESSAGE_ENABLED = 'false';
+            startApp();
+            const response = await request(app).get('/start-chat');
+            const actual = response.res.text;
+            const expected = 'class="moj-banner__message"';
+            expect(actual).not.toContain(expected);
+        });
+
+        describe('Maintenance message content', () => {
+            it('Should display default maintenance banner content if env var is nor present', async () => {
+                process.env.CW_LIVECHAT_MAINTENANCE_MESSAGE_ENABLED = 'true';
+                delete process.env.CW_LIVECHAT_MAINTENANCE_MESSAGE;
+                startApp();
+                const response = await request(app).get('/start-chat');
+                const actual = response.res.text;
+                const expected = 'maintenance message not set';
+                expect(actual).toContain(expected);
+            });
+
+            it('Should display default maintenance banner content if env var is "undefined"', async () => {
+                process.env.CW_LIVECHAT_MAINTENANCE_MESSAGE_ENABLED = 'true';
+                process.env.CW_LIVECHAT_MAINTENANCE_MESSAGE = undefined;
+                startApp();
+                const response = await request(app).get('/start-chat');
+                const actual = response.res.text;
+                const expected = 'maintenance message not set';
+                expect(actual).toContain(expected);
+            });
+
+            it('Should display default maintenance banner content if env var is "null"', async () => {
+                process.env.CW_LIVECHAT_MAINTENANCE_MESSAGE_ENABLED = 'true';
+                process.env.CW_LIVECHAT_MAINTENANCE_MESSAGE = null;
+                startApp();
+                const response = await request(app).get('/start-chat');
+                const actual = response.res.text;
+                const expected = 'maintenance message not set';
+                expect(actual).toContain(expected);
+            });
+
+            it('Should display default maintenance banner content if env var is an empty string', async () => {
+                process.env.CW_LIVECHAT_MAINTENANCE_MESSAGE_ENABLED = 'true';
+                process.env.CW_LIVECHAT_MAINTENANCE_MESSAGE = '';
+                startApp();
+                const response = await request(app).get('/start-chat');
+                const actual = response.res.text;
+                const expected = 'maintenance message not set';
+                expect(actual).toContain(expected);
+            });
+
+            it('Should display custom maintenance banner content', async () => {
+                process.env.CW_LIVECHAT_MAINTENANCE_MESSAGE_ENABLED = 'true';
+                process.env.CW_LIVECHAT_MAINTENANCE_MESSAGE = 'custom banner message';
+                startApp();
+                const response = await request(app).get('/start-chat');
+                const actual = response.res.text;
+                const expected = 'custom banner message';
+                expect(actual).toContain(expected);
+            });
+        });
+    });
+});

--- a/test/livechat-helper.test.js
+++ b/test/livechat-helper.test.js
@@ -17,6 +17,8 @@ describe('Live Chat Helper', () => {
             expect(result).toBe(true);
         });
         it('should return false for being the wrong day', () => {
+            process.env.CW_LIVECHAT_START_TIMES =
+                '00:00:01.000,00:00:01.000,00:00:01.000,00:00:01.000,00:00:01.000,00:00:01.000,false';
             jest.useFakeTimers('modern');
             jest.setSystemTime(new Date(2021, 8, 11, 4, 0, 48)); // Sat Sep 11 2021 04:00:48 GMT+0100 (British Summer Time)
             const liveChatHelper = createLiveChatHelper();
@@ -28,6 +30,10 @@ describe('Live Chat Helper', () => {
             expect(result).toBe(false);
         });
         it('should return false for being the wrong time on a correct day', () => {
+            process.env.CW_LIVECHAT_START_TIMES =
+                '00:00:01.000,08:30:00.000,00:00:01.000,00:00:01.000,00:00:01.000,00:00:01.000,false';
+            process.env.CW_LIVECHAT_END_TIMES =
+                '23:59:59.000,23:59:59.000,23:59:59.000,23:59:59.000,23:59:59.000,23:59:59.000,23:59:59.000';
             jest.useFakeTimers('modern');
             jest.setSystemTime(new Date(2021, 8, 13, 4, 0, 48)); // Mon Sep 13 2021 04:00:48 GMT+0100 (British Summer Time)
             const liveChatHelper = createLiveChatHelper();


### PR DESCRIPTION
Allow the following to be controlled by environment variable and avoid the need for a deployment:
* enabling and disabling live chat
* enabling and disabling the live chat maintenance banner
* customising live chat maintenance banner message
* live chat opening and closing times

Documentation for operation, and any rational behind coding decisions can be found here: https://github.com/CriminalInjuriesCompensationAuthority/q-dev-utilities/wiki/Live-chat


proposed version bump: `v4.1.0`

