### PR TITLE
Feature/248/track summary download

### DIFF
--- a/partials/modal-timeout.njk
+++ b/partials/modal-timeout.njk
@@ -34,7 +34,8 @@
         text: "Continue application",
         classes: "govuk-modal__continue ga-event--click",
         attributes: {
-            "data-tracking-category": "modal-button"
+            "data-tracking-category": "modal-button",
+            "data-tracking-label": "Continue application"
         }
     }) }}
 {% endcall %}
@@ -55,7 +56,8 @@
         href: "/apply",
         classes: "ga-event--click",
         attributes: {
-            "data-tracking-category": "modal-button"
+            "data-tracking-category": "modal-button",
+            "data-tracking-label": "Start again"
         }
     }) }}
 {% endcall %}
@@ -76,7 +78,8 @@
         href: "/apply",
         classes: "ga-event--click",
         attributes: {
-            "data-tracking-category": "modal-button"
+            "data-tracking-category": "modal-button",
+            "data-tracking-label": "Start again"
         }
     }) }}
 {% endcall %}

--- a/public/dist/js/bundle.js
+++ b/public/dist/js/bundle.js
@@ -23687,7 +23687,7 @@ function createCicaGa(window) {
     trackableElements.forEach(function (element) {
       if (element.classList.contains('ga-event--click')) {
         click(element, {
-          label: element.getAttribute('data-tracking-label') || element.innerText && element.innerText.trim() || element.innerHTML && element.innerHTML.trim(),
+          label: element.getAttribute('data-tracking-label') || element.href || element.innerText && element.innerText.trim() || element.innerHTML && element.innerHTML.trim(),
           category: element.getAttribute('data-tracking-category') || element.tagName
         });
         return;

--- a/questionnaire/form-helper.js
+++ b/questionnaire/form-helper.js
@@ -70,7 +70,8 @@ function renderSection({
                         ${transformation.content}
                     {% if ${showButton} %}
                         {{ govukButton({
-                            text: "${buttonTitle}"
+                            text: "${buttonTitle}",
+                            preventDoubleClick: true
                         }) }}
                     {% endif %}
                     <input type="hidden" name="_csrf" value="${csrfToken}">

--- a/src/modules/ga/index.js
+++ b/src/modules/ga/index.js
@@ -155,6 +155,7 @@ function createCicaGa(window) {
                 click(element, {
                     label:
                         element.getAttribute('data-tracking-label') ||
+                        element.href ||
                         (element.innerText && element.innerText.trim()) ||
                         (element.innerHTML && element.innerHTML.trim()),
                     category: element.getAttribute('data-tracking-category') || element.tagName

--- a/test/test-fixtures/transformations/resolved html/p-applicant-british-citizen-or-eu-national.js
+++ b/test/test-fixtures/transformations/resolved html/p-applicant-british-citizen-or-eu-national.js
@@ -219,7 +219,7 @@ const html = `<!DOCTYPE html>
 
 
 
-<button class="govuk-button" data-module="govuk-button">
+<button data-prevent-double-click="true" class="govuk-button" data-module="govuk-button">
   Continue
 </button>
 <input type="hidden" name="_csrf" value="sometoken">
@@ -370,7 +370,7 @@ const html = `<!DOCTYPE html>
     
   
 
-                    <button class="govuk-button govuk-modal__continue ga-event--click" data-module="govuk-button" data-tracking-category="modal-button">Continue application</button>
+                    <button class="govuk-button govuk-modal__continue ga-event--click" data-module="govuk-button" data-tracking-category="modal-button" data-tracking-label="Continue application">Continue application</button>
 
                 
             </div>
@@ -442,7 +442,7 @@ const html = `<!DOCTYPE html>
   
     
   
-                    <a href="/apply" role="button" draggable="false" class="govuk-button ga-event--click" data-module="govuk-button" data-tracking-category="modal-button">Start again</a>
+                    <a href="/apply" role="button" draggable="false" class="govuk-button ga-event--click" data-module="govuk-button" data-tracking-category="modal-button" data-tracking-label="Start again">Start again</a>
 
 
                 
@@ -528,7 +528,7 @@ const html = `<!DOCTYPE html>
   
     
   
-                    <a href="/apply" role="button" draggable="false" class="govuk-button ga-event--click" data-module="govuk-button" data-tracking-category="modal-button">Start again</a>
+                    <a href="/apply" role="button" draggable="false" class="govuk-button ga-event--click" data-module="govuk-button" data-tracking-category="modal-button" data-tracking-label="Start again">Start again</a>
 
 
                 


### PR DESCRIPTION
* If `element.getAttribute('data-tracking-label')` is "falsy", then it initially falls back to the newly-introduced `element.href` property. This is to cater for the download link URL being tracked by GA. Due to this change of order of precedence, a `"data-tracking-label": "something something"` has been added to legacy elements. This addition of the `data-tracking-label` will allow it render what is was previously and not fall back to `element.href`.

* Added `preventDoubleClick` to submit button