### PR TITLE
Add maintenance banner

### DIFF
--- a/app.js
+++ b/app.js
@@ -47,6 +47,16 @@ nunjucks
     .addGlobal(
         'CW_LIVECHAT_MAINTENANCE_MESSAGE_ENABLED',
         process.env.CW_LIVECHAT_MAINTENANCE_MESSAGE_ENABLED === 'true'
+    )
+    .addGlobal(
+        'CW_MAINTENANCE_MESSAGE',
+        !process.env?.CW_MAINTENANCE_MESSAGE?.length
+            ? 'maintenance message not set'
+            : process.env.CW_MAINTENANCE_MESSAGE
+    )
+    .addGlobal(
+        'CW_MAINTENANCE_MESSAGE_ENABLED',
+        process.env.CW_MAINTENANCE_MESSAGE_ENABLED === 'true'
     );
 
 app.use((req, res, next) => {

--- a/kube_deploy/Dev/deploy.yml
+++ b/kube_deploy/Dev/deploy.yml
@@ -66,6 +66,16 @@ spec:
                 secretKeyRef:
                   name: cica-web-secrets
                   key: cw_livechat_maintenance_message
+            - name: CW_MAINTENANCE_MESSAGE
+              valueFrom:
+                secretKeyRef:
+                  name: cica-web-secrets
+                  key: cw_maintenance_message
+            - name: CW_MAINTENANCE_MESSAGE_ENABLED
+              valueFrom:
+                secretKeyRef:
+                  name: cica-web-secrets
+                  key: cw_maintenance_message_enabled
   selector:
     matchLabels:
       app: webapp-dev

--- a/kube_deploy/Prod/deploy.yml
+++ b/kube_deploy/Prod/deploy.yml
@@ -66,6 +66,16 @@ spec:
                 secretKeyRef:
                   name: cica-web-secrets
                   key: cw_livechat_maintenance_message
+            - name: CW_MAINTENANCE_MESSAGE
+              valueFrom:
+                secretKeyRef:
+                  name: cica-web-secrets
+                  key: cw_maintenance_message
+            - name: CW_MAINTENANCE_MESSAGE_ENABLED
+              valueFrom:
+                secretKeyRef:
+                  name: cica-web-secrets
+                  key: cw_maintenance_message_enabled
   selector:
     matchLabels:
       app: webapp-prod

--- a/kube_deploy/Uat/deploy.yml
+++ b/kube_deploy/Uat/deploy.yml
@@ -66,6 +66,16 @@ spec:
                 secretKeyRef:
                   name: cica-web-secrets
                   key: cw_livechat_maintenance_message
+            - name: CW_MAINTENANCE_MESSAGE
+              valueFrom:
+                secretKeyRef:
+                  name: cica-web-secrets
+                  key: cw_maintenance_message
+            - name: CW_MAINTENANCE_MESSAGE_ENABLED
+              valueFrom:
+                secretKeyRef:
+                  name: cica-web-secrets
+                  key: cw_maintenance_message_enabled
   selector:
     matchLabels:
       app: webapp-uat

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "cica-web",
-    "version": "5.0.7",
+    "version": "5.1.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "cica-web",
-            "version": "5.0.7",
+            "version": "5.1.0",
             "license": "MIT",
             "dependencies": {
                 "@ministryofjustice/frontend": "0.0.17-alpha",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cica-web",
-    "version": "5.0.7",
+    "version": "5.1.0",
     "engines": {
         "npm": ">=8.5.2",
         "node": ">=16.0.0"

--- a/page/page.njk
+++ b/page/page.njk
@@ -1,4 +1,5 @@
 {% extends "template.njk" %}
+{%- from "moj/components/banner/macro.njk" import mojBanner -%}
 
 {% block pageTitle %}Claim criminal injuries compensation - GOV.UK{% endblock %}
 {% block head %}
@@ -70,6 +71,19 @@
 {% block content %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
+            {% if CW_MAINTENANCE_MESSAGE_ENABLED %}
+
+                {% set bannerHtml %}
+                    <p class="govuk-body">{{ CW_MAINTENANCE_MESSAGE }}</p>
+                {% endset %}
+
+                {{ mojBanner({
+                    type: 'information',
+                    html: bannerHtml
+                }) }}
+
+            {% endif %}
+
             {% block innerContent %}
             {% endblock %}
         </div>

--- a/src/sass/all-ie8.scss
+++ b/src/sass/all-ie8.scss
@@ -2,3 +2,4 @@
 @import "src/modules/cookie-banner/cookie-banner";
 @import "components/cica/modal/modal";
 @import "src/modules/live-chat/live-chat";
+@import "node_modules/@ministryofjustice/frontend/moj/components/banner/_banner";

--- a/src/sass/all.scss
+++ b/src/sass/all.scss
@@ -2,3 +2,4 @@
 @import "src/modules/cookie-banner/cookie-banner";
 @import "components/cica/modal/modal";
 @import "src/modules/live-chat/live-chat";
+@import "node_modules/@ministryofjustice/frontend/moj/components/banner/_banner";


### PR DESCRIPTION
Added ability to enable and disable the maintenance banner on the fly via applying new secrets to the running web app.

* Added reference to new secrets; `CW_MAINTENANCE_MESSAGE`, and `CW_MAINTENANCE_MESSAGE_ENABLED`.
* Added banner Nunjucks components to globally inherited `njk` template.
* BUG: Added back missing sass file references to sass entry file. Now the correct CSS will be generated using the NPM script.

Proposed version bump: `5.1.0` (minor bump)