### PR TITLE
Feature/cica 315/session

### DIFF
--- a/app.js
+++ b/app.js
@@ -125,7 +125,7 @@ app.use('/apply', async (req, res, next) => {
     // download too?
     if (req?.session?.questionnaireId) {
         const response = await qService.keepAlive(req.session.questionnaireId);
-        const sessionData = response.body;
+        const sessionData = response.body.data;
         const sessionDuration = sessionData[0].attributes.duration;
         const bufferDuration = 30000;
         req.session.cookie.maxAge = sessionDuration - bufferDuration;
@@ -154,8 +154,7 @@ app.use(['/apply', '/download'], async (req, res, next) => {
             }
             return res.redirect(redirectionUrl);
         } catch (err) {
-            res.status(404).render('404.njk');
-            next(err);
+            return res.status(404).render('404.njk');
         }
     }
     next(); // <-- important!

--- a/download/routes.js
+++ b/download/routes.js
@@ -11,7 +11,7 @@ const router = express.Router();
 router.route('/application-summary').get(async (req, res, next) => {
     try {
         const response = await qService.getSection(
-            req.cicaSession.questionnaireId,
+            req.session.questionnaireId,
             'p--check-your-answers'
         );
         const timestamp = moment().tz('Europe/London');

--- a/download/test/download.routes.test.js
+++ b/download/test/download.routes.test.js
@@ -57,32 +57,31 @@ describe('Download route service endpoint', () => {
                         jest.resetModules();
                         jest.doMock('../../questionnaire/questionnaire-service', () =>
                             jest.fn(() => ({
-                                createQuestionnaire: () => createQuestionnaire
+                                createQuestionnaire: () => createQuestionnaire,
+                                getSection: () => getSectionValid
                             }))
                         );
                         jest.doMock('../../questionnaire/form-helper', () => ({
                             removeSectionIdPrefix: () => initial
                         }));
-
-                        // eslint-disable-next-line global-require
-                        app = require('../../app');
                         jest.doMock('../download-helper', () => ({
                             getSummaryHtml: () => {
                                 throw new Error();
                             }
                         }));
+
+                        // eslint-disable-next-line global-require
+                        app = require('../../app');
+
                         const currentAgent = request.agent(app);
-                        return currentAgent.get('/apply/').then(() => {
-                            currentAgent
-                                .get('/download/application-summary')
-                                .set(
-                                    'Cookie',
-                                    'session=te3AFsfQozY49T4FIL8lEA.K2YvZ_eUm0YcCg2IA_qtCorcS2T17Td11LC0WmYuTaWc5PQuHcoCTHPuOPQoWVy_R5tUX4vzV4_pENOBxk1xPg0obdlP4suxaGK2YdqxjAE.1565864591496.900000.NwyQHlNP62CAiD-sk2GuuJvLzAQEZjX364hfnLp06yA;'
-                                )
-                                .then(response => {
-                                    expect(response.statusCode).toBe(404);
-                                });
-                        });
+                        await currentAgent.get('/apply/');
+                        const response = await currentAgent
+                            .get('/download/application-summary')
+                            .set(
+                                'Cookie',
+                                'session=te3AFsfQozY49T4FIL8lEA.K2YvZ_eUm0YcCg2IA_qtCorcS2T17Td11LC0WmYuTaWc5PQuHcoCTHPuOPQoWVy_R5tUX4vzV4_pENOBxk1xPg0obdlP4suxaGK2YdqxjAE.1565864591496.900000.NwyQHlNP62CAiD-sk2GuuJvLzAQEZjX364hfnLp06yA;'
+                            );
+                        expect(response.statusCode).toBe(404);
                     });
                 });
 

--- a/download/test/download.routes.test.js
+++ b/download/test/download.routes.test.js
@@ -42,7 +42,7 @@ describe('Download route service endpoint', () => {
                                 .get('/download/application-summary')
                                 .set(
                                     'Cookie',
-                                    'cicaSession=te3AFsfQozY49T4FIL8lEA.K2YvZ_eUm0YcCg2IA_qtCorcS2T17Td11LC0WmYuTaWc5PQuHcoCTHPuOPQoWVy_R5tUX4vzV4_pENOBxk1xPg0obdlP4suxaGK2YdqxjAE.1565864591496.900000.NwyQHlNP62CAiD-sk2GuuJvLzAQEZjX364hfnLp06yA;'
+                                    'session=te3AFsfQozY49T4FIL8lEA.K2YvZ_eUm0YcCg2IA_qtCorcS2T17Td11LC0WmYuTaWc5PQuHcoCTHPuOPQoWVy_R5tUX4vzV4_pENOBxk1xPg0obdlP4suxaGK2YdqxjAE.1565864591496.900000.NwyQHlNP62CAiD-sk2GuuJvLzAQEZjX364hfnLp06yA;'
                                 )
                                 .then(response => {
                                     expect(response.statusCode).toBe(200);
@@ -77,7 +77,7 @@ describe('Download route service endpoint', () => {
                                 .get('/download/application-summary')
                                 .set(
                                     'Cookie',
-                                    'cicaSession=te3AFsfQozY49T4FIL8lEA.K2YvZ_eUm0YcCg2IA_qtCorcS2T17Td11LC0WmYuTaWc5PQuHcoCTHPuOPQoWVy_R5tUX4vzV4_pENOBxk1xPg0obdlP4suxaGK2YdqxjAE.1565864591496.900000.NwyQHlNP62CAiD-sk2GuuJvLzAQEZjX364hfnLp06yA;'
+                                    'session=te3AFsfQozY49T4FIL8lEA.K2YvZ_eUm0YcCg2IA_qtCorcS2T17Td11LC0WmYuTaWc5PQuHcoCTHPuOPQoWVy_R5tUX4vzV4_pENOBxk1xPg0obdlP4suxaGK2YdqxjAE.1565864591496.900000.NwyQHlNP62CAiD-sk2GuuJvLzAQEZjX364hfnLp06yA;'
                                 )
                                 .then(response => {
                                     expect(response.statusCode).toBe(404);

--- a/index/routes.js
+++ b/index/routes.js
@@ -60,7 +60,7 @@ router.get('/chat', (req, res) => {
 });
 
 router.get('*', (req, res) => {
-    res.render('404.njk');
+    res.status(404).render('404.njk');
 });
 
 module.exports = router;

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
                 "debounce": "^1.2.0",
                 "debug": "~2.6.9",
                 "express": "~4.16.0",
+                "express-session": "^1.17.3",
                 "got": "^11.8.5",
                 "govuk-frontend": "^3.10.2",
                 "helmet": "^3.15.0",
@@ -7244,6 +7245,59 @@
             "engines": {
                 "node": ">= 0.10.0"
             }
+        },
+        "node_modules/express-session": {
+            "version": "1.17.3",
+            "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.17.3.tgz",
+            "integrity": "sha512-4+otWXlShYlG1Ma+2Jnn+xgKUZTMJ5QD3YvfilX3AcocOAbIkVylSWEklzALe/+Pu4qV6TYBj5GwOBFfdKqLBw==",
+            "dependencies": {
+                "cookie": "0.4.2",
+                "cookie-signature": "1.0.6",
+                "debug": "2.6.9",
+                "depd": "~2.0.0",
+                "on-headers": "~1.0.2",
+                "parseurl": "~1.3.3",
+                "safe-buffer": "5.2.1",
+                "uid-safe": "~2.1.5"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/express-session/node_modules/cookie": {
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+            "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/express-session/node_modules/depd": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+            "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/express-session/node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ]
         },
         "node_modules/express/node_modules/cookie": {
             "version": "0.3.1",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
         "debounce": "^1.2.0",
         "debug": "~2.6.9",
         "express": "~4.16.0",
+        "express-session": "^1.17.3",
         "got": "^11.8.5",
         "govuk-frontend": "^3.10.2",
         "helmet": "^3.15.0",

--- a/questionnaire/questionnaire-service.js
+++ b/questionnaire/questionnaire-service.js
@@ -144,6 +144,26 @@ function questionnaireService() {
         return service.get(opts);
     }
 
+    function getSessionData(questionnaireId) {
+        const opts = {
+            url: `${process.env.CW_DCS_URL}/api/v1/questionnaires/${questionnaireId}/session`,
+            headers: {
+                Authorization: `Bearer ${process.env.CW_DCS_JWT}`
+            }
+        };
+        return service.get(opts);
+    }
+
+    function keepAlive(questionnaireId) {
+        const opts = {
+            url: `${process.env.CW_DCS_URL}/api/v1/questionnaires/${questionnaireId}/session/keep-alive`,
+            headers: {
+                Authorization: `Bearer ${process.env.CW_DCS_JWT}`
+            }
+        };
+        return service.get(opts);
+    }
+
     return Object.freeze({
         createQuestionnaire,
         getSection,
@@ -154,7 +174,9 @@ function questionnaireService() {
         postSubmission,
         timeout,
         getSubmissionStatus,
-        getFirstSection
+        getFirstSection,
+        getSessionData,
+        keepAlive
     });
 }
 

--- a/questionnaire/routes.js
+++ b/questionnaire/routes.js
@@ -6,7 +6,7 @@ const qService = require('./questionnaire-service')();
 
 const router = express.Router();
 
-router.route('/').get(async (req, res, next) => {
+router.route('/').get(async (req, res) => {
     try {
         const response = await qService.getFirstSection(req.session.questionnaireId);
         const responseBody = response.body;
@@ -16,11 +16,10 @@ router.route('/').get(async (req, res, next) => {
         res.redirect(`${req.baseUrl}/${initialSection}`);
     } catch (err) {
         res.status(err.statusCode || 404).render('404.njk');
-        next(err);
     }
 });
 
-router.route('/previous/:section').get(async (req, res, next) => {
+router.route('/previous/:section').get(async (req, res) => {
     try {
         const sectionId = formHelper.addPrefix(req.params.section);
         const response = await qService.getPrevious(req.session.questionnaireId, sectionId);
@@ -33,8 +32,7 @@ router.route('/previous/:section').get(async (req, res, next) => {
         );
         return res.redirect(`${req.baseUrl}/${previousSectionId}`);
     } catch (err) {
-        res.status(err.statusCode || 404).render('404.njk');
-        return next(err);
+        return res.status(err.statusCode || 404).render('404.njk');
     }
 });
 

--- a/questionnaire/routes.js
+++ b/questionnaire/routes.js
@@ -8,7 +8,7 @@ const router = express.Router();
 
 router.route('/').get(async (req, res, next) => {
     try {
-        const response = await qService.getFirstSection(req.cicaSession.questionnaireId);
+        const response = await qService.getFirstSection(req.session.questionnaireId);
         const responseBody = response.body;
         const initialSection = formHelper.removeSectionIdPrefix(
             responseBody.data[0].attributes.sectionId
@@ -23,7 +23,7 @@ router.route('/').get(async (req, res, next) => {
 router.route('/previous/:section').get(async (req, res, next) => {
     try {
         const sectionId = formHelper.addPrefix(req.params.section);
-        const response = await qService.getPrevious(req.cicaSession.questionnaireId, sectionId);
+        const response = await qService.getPrevious(req.session.questionnaireId, sectionId);
         if (response.body.data[0].attributes && response.body.data[0].attributes.url !== null) {
             const overwriteId = response.body.data[0].attributes.url;
             return res.redirect(overwriteId);
@@ -43,7 +43,7 @@ router
     .get(async (req, res, next) => {
         try {
             const sectionId = formHelper.addPrefix(req.params.section);
-            const response = await qService.getSection(req.cicaSession.questionnaireId, sectionId);
+            const response = await qService.getSection(req.session.questionnaireId, sectionId);
             if (
                 response.body.data &&
                 response.body.data[0].attributes &&
@@ -67,7 +67,7 @@ router
                 res.locals.nonce
             );
             if (formHelper.getSectionContext(sectionId) === 'confirmation') {
-                req.cicaSession.reset();
+                req.session.reset();
             }
             res.send(html);
         } catch (err) {
@@ -84,7 +84,7 @@ router
             // eslint-disable-next-line no-underscore-dangle
             delete body._csrf;
             const response = await qService.postSection(
-                req.cicaSession.questionnaireId,
+                req.session.questionnaireId,
                 sectionId,
                 body
             );
@@ -94,9 +94,9 @@ router
                     formHelper.getSectionContext(sectionId) === 'submission';
                 if (isApplicationSubmission) {
                     try {
-                        await qService.postSubmission(req.cicaSession.questionnaireId);
+                        await qService.postSubmission(req.session.questionnaireId);
                         const submissionResponse = await qService.getSubmissionStatus(
-                            req.cicaSession.questionnaireId,
+                            req.session.questionnaireId,
                             Date.now()
                         );
 
@@ -114,7 +114,7 @@ router
 
                 if ('next' in req.query) {
                     const progressEntryResponse = await qService.getSection(
-                        req.cicaSession.questionnaireId,
+                        req.session.questionnaireId,
                         formHelper.addPrefix(req.query.next)
                     );
 
@@ -127,7 +127,7 @@ router
                 }
 
                 const progressEntryResponse = await qService.getCurrentSection(
-                    req.cicaSession.questionnaireId
+                    req.session.questionnaireId
                 );
                 nextSectionId = formHelper.removeSectionIdPrefix(
                     progressEntryResponse.body.data[0].attributes.sectionId

--- a/session/routes.js
+++ b/session/routes.js
@@ -5,23 +5,21 @@ const qService = require('../questionnaire/questionnaire-service')();
 
 const router = express.Router();
 
-router.route('/').get(async (req, res, next) => {
+router.route('/').get(async (req, res) => {
     try {
         const response = await qService.getSessionData(req.session.questionnaireId);
         res.json(response.body);
     } catch (err) {
         res.status(err.statusCode || 404).render('404.njk');
-        next(err);
     }
 });
 
-router.route('/keep-alive').get(async (req, res, next) => {
+router.route('/keep-alive').get(async (req, res) => {
     try {
         const response = await qService.keepAlive(req.session.questionnaireId);
         res.json(response.body);
     } catch (err) {
         res.status(err.statusCode || 404).render('404.njk');
-        next(err);
     }
 });
 

--- a/session/routes.js
+++ b/session/routes.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const express = require('express');
+const qService = require('../questionnaire/questionnaire-service')();
+
+const router = express.Router();
+
+router.route('/').get(async (req, res, next) => {
+    try {
+        const response = await qService.getSessionData(req.cicaSession.questionnaireId);
+        res.json(response.body);
+    } catch (err) {
+        res.status(err.statusCode || 404).render('404.njk');
+        next(err);
+    }
+});
+
+router.route('/keep-alive').get(async (req, res, next) => {
+    try {
+        const response = await qService.keepAlive(req.cicaSession.questionnaireId);
+        res.json(response.body);
+    } catch (err) {
+        res.status(err.statusCode || 404).render('404.njk');
+        next(err);
+    }
+});
+
+module.exports = router;

--- a/session/routes.js
+++ b/session/routes.js
@@ -7,7 +7,7 @@ const router = express.Router();
 
 router.route('/').get(async (req, res, next) => {
     try {
-        const response = await qService.getSessionData(req.cicaSession.questionnaireId);
+        const response = await qService.getSessionData(req.session.questionnaireId);
         res.json(response.body);
     } catch (err) {
         res.status(err.statusCode || 404).render('404.njk');
@@ -17,7 +17,7 @@ router.route('/').get(async (req, res, next) => {
 
 router.route('/keep-alive').get(async (req, res, next) => {
     try {
-        const response = await qService.keepAlive(req.cicaSession.questionnaireId);
+        const response = await qService.keepAlive(req.session.questionnaireId);
         res.json(response.body);
     } catch (err) {
         res.status(err.statusCode || 404).render('404.njk');

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -6,16 +6,30 @@ const csrf = require('csurf');
 const formHelper = require('../questionnaire/form-helper');
 
 const createQuestionnaire = require('./test-fixtures/res/get_questionnaire.json');
-
 const getCurrentSection = require('./test-fixtures/res/get_current_section_valid');
 const getSectionValid = require('./test-fixtures/res/get_schema_valid');
 const getSectionHtmlValid = require('./test-fixtures/transformations/resolved html/p-some-section');
 const getProgressEntries = require('./test-fixtures/res/progress_entry_example');
-const getProgressEntriesErrors = require('./test-fixtures/res/post_section_returned_errors');
 const getPreviousValid = require('./test-fixtures/res/get_previous_valid_sectionId');
 const getPreviousValidUrl = require('./test-fixtures/res/get_previous_valid_url');
 const postValidSubmission = require('./test-fixtures/res/post_valid_submission');
 const postValidSubmissionServiceDown = require('./test-fixtures/res/post_valid_submission_service_down');
+
+const keepAlive = {
+    body: {
+        data: [
+            {
+                id: '285cb104-0c15-4a9c-9840-cb1007f098fb',
+                type: 'sessions',
+                attributes: {
+                    alive: true,
+                    duration: 900000,
+                    created: '2022-08-11T20:26:35Z'
+                }
+            }
+        ]
+    }
+};
 
 let app;
 
@@ -64,575 +78,418 @@ function replaceCsrfMiddlwareForTest(expressApp) {
     expressApp._router.stack.splice(csrfMiddlewareStackIndex, 0, newCsrfMiddlewareStackItem);
 }
 
-function setUpCommonMocks() {
+function setUpCommonMocks(additionalMocks) {
     jest.resetModules();
-    jest.doMock('../questionnaire/questionnaire-service', () =>
-        jest.fn(() => ({
-            createQuestionnaire: () => createQuestionnaire,
-            getCurrentSection: () => getCurrentSection
-        }))
-    );
+    jest.restoreAllMocks();
+    jest.unmock('../questionnaire/questionnaire-service');
+    jest.unmock('../questionnaire/form-helper');
+    jest.unmock('../index/liveChatHelper');
+    jest.unmock('../questionnaire/request-service');
+    jest.unmock('express-session');
+    if (additionalMocks) {
+        additionalMocks();
+    } else {
+        jest.doMock('../questionnaire/questionnaire-service', () =>
+            jest.fn(() => ({
+                createQuestionnaire: () => createQuestionnaire,
+                getCurrentSection: () => getCurrentSection,
+                keepAlive: () => keepAlive
+            }))
+        );
+    }
     // eslint-disable-next-line global-require
     app = require('../app');
     replaceCsrfMiddlwareForTest(app);
 }
 
-describe('Data capture service endpoints', () => {
-    describe('Cica-web static routes', () => {
+describe('Static routes', () => {
+    beforeEach(() => {
+        jest.resetModules();
+        jest.restoreAllMocks();
         // eslint-disable-next-line global-require
         app = require('../app');
-        replaceCsrfMiddlwareForTest(app);
+    });
 
-        describe('/', () => {
-            describe('GET', () => {
-                describe('200', () => {
-                    it('Should respond with a 200 status', async () => {
-                        const response = await request(app).get('/');
-                        expect(response.statusCode).toBe(301);
-                        expect(response.get('location')).toEqual(
-                            'https://www.gov.uk/claim-compensation-criminal-injury/make-claim'
-                        );
-                    });
-                });
-            });
-            describe('/cookies', () => {
-                describe('GET', () => {
-                    describe('200', () => {
-                        it('Should respond with a 200 status', async () => {
-                            const response = await request(app).get('/cookies');
-                            expect(response.statusCode).toBe(200);
-                        });
-                        it('Should render a page with the start page heading', async () => {
-                            const response = await request(app).get('/cookies');
-                            const actual = response.res.text.replace(/\s+/g, '');
-                            const pageHeading = `<h1 class="govuk-heading-xl">Cookies</h1>`.replace(
-                                /\s+/g,
-                                ''
-                            );
-                            expect(actual).toContain(pageHeading);
-                        });
-                    });
-                });
-            });
-            describe('/contact-us', () => {
-                describe('GET', () => {
-                    describe('200', () => {
-                        it('Should respond with a 200 status', async () => {
-                            const response = await request(app).get('/contact-us');
-                            expect(response.statusCode).toBe(200);
-                        });
-                        it('Should render a page with the start page heading', async () => {
-                            const response = await request(app).get('/contact-us');
-                            const actual = response.res.text.replace(/\s+/g, '');
-                            const pageHeading = `<h1 class="govuk-heading-xl">Contact us</h1>`.replace(
-                                /\s+/g,
-                                ''
-                            );
-                            expect(actual).toContain(pageHeading);
-                        });
-                    });
-                });
-            });
-            describe('/accessibility-statement', () => {
-                describe('GET', () => {
-                    describe('200', () => {
-                        it('Should respond with a 200 status', async () => {
-                            const response = await request(app).get('/accessibility-statement');
-                            expect(response.statusCode).toBe(200);
-                        });
-                        it('Should render a page with the accessibility statement page heading', async () => {
-                            const response = await request(app).get('/accessibility-statement');
-                            const actual = response.res.text.replace(/\s+/g, '');
-                            const pageHeading = `<h1 class="govuk-heading-xl">Accessibility for Claim criminal injuries compensation</h1>`.replace(
-                                /\s+/g,
-                                ''
-                            );
-                            expect(actual).toContain(pageHeading);
-                        });
-                    });
-                });
-            });
-            describe('/police-forces', () => {
-                describe('GET', () => {
-                    describe('200', () => {
-                        it('Should respond with a 200 status', async () => {
-                            const response = await request(app).get('/police-forces');
-                            expect(response.statusCode).toBe(200);
-                        });
-                        it('Should render a specific content on the page', async () => {
-                            const response = await request(app).get('/police-forces');
-                            const actual = response.res.text.replace(/\s+/g, '');
-                            const pageHeading = `<h1 class="govuk-heading-xl">Police forces</h1>`.replace(
-                                /\s+/g,
-                                ''
-                            );
-                            expect(actual).toContain(pageHeading);
-                        });
-                    });
-                });
-            });
-            describe('/start-chat', () => {
-                describe('GET', () => {
-                    describe('200', () => {
-                        it('Should respond with a 200 status', async () => {
-                            const response = await request(app).get('/start-chat');
-                            expect(response.statusCode).toBe(200);
-                        });
-                        it('Should render specific content on the page', async () => {
-                            jest.resetModules();
-                            jest.doMock('../index/liveChatHelper', () =>
-                                jest.fn(() => ({
-                                    isLiveChatActive: () => {
-                                        return true;
-                                    }
-                                }))
-                            );
+    describe('/', () => {
+        it('should redirect to GOV UK landing page', async () => {
+            const response = await request(app).get('/');
+            expect(response.statusCode).toBe(301);
+            expect(response.get('location')).toEqual(
+                'https://www.gov.uk/claim-compensation-criminal-injury/make-claim'
+            );
+        });
+    });
 
-                            // eslint-disable-next-line global-require
-                            app = require('../app');
-                            const response = await request(app).get('/start-chat');
-                            const actual = response.res.text.replace(/\s+/g, '');
-                            const pageHeading = `<h1 class="govuk-heading-xl">Chat to us online</h1>`.replace(
-                                /\s+/g,
-                                ''
-                            );
-                            expect(actual).toContain(pageHeading);
-                        });
-                        it('Should render a 404 page', async () => {
-                            jest.resetModules();
-                            jest.doMock('../index/liveChatHelper', () =>
-                                jest.fn(() => ({
-                                    isLiveChatActive: () => {
-                                        return false;
-                                    }
-                                }))
-                            );
+    describe('/cookies', () => {
+        it('Should respond with a 200 status code', async () => {
+            const response = await request(app).get('/cookies');
+            expect(response.statusCode).toBe(200);
+        });
+        it('Should render a page with the correct page heading', async () => {
+            const response = await request(app).get('/cookies');
+            const actual = response.res.text.replace(/\s+/g, '');
+            const pageHeading = `<h1 class="govuk-heading-xl">Cookies</h1>`.replace(/\s+/g, '');
+            expect(actual).toContain(pageHeading);
+        });
+    });
 
-                            // eslint-disable-next-line global-require
-                            app = require('../app');
-                            const response = await request(app).get('/start-chat');
-                            const actual = response.res.text.replace(/\s+/g, '');
-                            const pageHeading = `<h1 class="govuk-heading-xl">Sorry, the service is unavailable</h1>`.replace(
-                                /\s+/g,
-                                ''
-                            );
-                            expect(actual).toContain(pageHeading);
-                        });
-                    });
-                });
+    describe('/contact-us', () => {
+        it('Should respond with a 200 status code', async () => {
+            const response = await request(app).get('/contact-us');
+            expect(response.statusCode).toBe(200);
+        });
+        it('Should render a page with the correct page heading', async () => {
+            const response = await request(app).get('/contact-us');
+            const actual = response.res.text.replace(/\s+/g, '');
+            const pageHeading = `<h1 class="govuk-heading-xl">Contact us</h1>`.replace(/\s+/g, '');
+            expect(actual).toContain(pageHeading);
+        });
+    });
+
+    describe('/accessibility-statement', () => {
+        it('Should respond with a 200 status code', async () => {
+            const response = await request(app).get('/accessibility-statement');
+            expect(response.statusCode).toBe(200);
+        });
+        it('Should render a page with the correct page heading', async () => {
+            const response = await request(app).get('/accessibility-statement');
+            const actual = response.res.text.replace(/\s+/g, '');
+            const pageHeading = `<h1 class="govuk-heading-xl">Accessibility for Claim criminal injuries compensation</h1>`.replace(
+                /\s+/g,
+                ''
+            );
+            expect(actual).toContain(pageHeading);
+        });
+    });
+
+    describe('/police-forces', () => {
+        it('Should respond with a 200 status code', async () => {
+            const response = await request(app).get('/police-forces');
+            expect(response.statusCode).toBe(200);
+        });
+        it('Should render a page with the correct page heading', async () => {
+            const response = await request(app).get('/police-forces');
+            const actual = response.res.text.replace(/\s+/g, '');
+            const pageHeading = `<h1 class="govuk-heading-xl">Police forces</h1>`.replace(
+                /\s+/g,
+                ''
+            );
+            expect(actual).toContain(pageHeading);
+        });
+    });
+
+    describe('/thisdoesntexist', () => {
+        it('Should respond with a 200 status code', async () => {
+            const response = await request(app).get('/thisdoesntexist');
+            expect(response.statusCode).toBe(404);
+        });
+        it('Should render a page with the correct page heading', async () => {
+            const response = await request(app).get('/thisdoesntexist');
+            const actual = response.res.text.replace(/\s+/g, '');
+            const pageHeading = `<h1 class="govuk-heading-xl">Page not found</h1>`.replace(
+                /\s+/g,
+                ''
+            );
+            expect(actual).toContain(pageHeading);
+        });
+    });
+
+    describe('/start-chat', () => {
+        it('Should respond with a 200 status code', async () => {
+            const response = await request(app).get('/start-chat');
+            expect(response.statusCode).toBe(200);
+        });
+        describe('When Live Chat is active', () => {
+            it('Should render specific content on the page', async () => {
+                jest.resetModules();
+                jest.doMock('../index/liveChatHelper', () =>
+                    jest.fn(() => ({
+                        isLiveChatActive: () => {
+                            return true;
+                        }
+                    }))
+                );
+
+                // eslint-disable-next-line global-require
+                app = require('../app');
+                const response = await request(app).get('/start-chat');
+                const actual = response.res.text.replace(/\s+/g, '');
+                const pageHeading = `<h1 class="govuk-heading-xl">Chat to us online</h1>`.replace(
+                    /\s+/g,
+                    ''
+                );
+                expect(actual).toContain(pageHeading);
             });
-            describe('/chat', () => {
-                describe('GET', () => {
-                    describe('200', () => {
-                        it('Should respond with a 200 status', async () => {
-                            const response = await request(app).get('/chat');
-                            expect(response.statusCode).toBe(200);
-                        });
-                        it('Should render specific content on the page', async () => {
-                            jest.resetModules();
-                            jest.doMock('../index/liveChatHelper', () =>
-                                jest.fn(() => ({
-                                    isLiveChatActive: () => {
-                                        return true;
-                                    }
-                                }))
-                            );
+        });
+        describe('When Live Chat is not active', () => {
+            it('Should render specific content on the page', async () => {
+                jest.resetModules();
+                jest.doMock('../index/liveChatHelper', () =>
+                    jest.fn(() => ({
+                        isLiveChatActive: () => {
+                            return false;
+                        }
+                    }))
+                );
 
-                            // eslint-disable-next-line global-require
-                            app = require('../app');
-                            const response = await request(app).get('/chat');
-                            const actual = response.res.text.replace(/\s+/g, '');
-                            const pageContent = `<iframe id="chat-iframe"`.replace(/\s+/g, '');
-                            expect(actual).toContain(pageContent);
-                        });
-                        it('Should render a 404 page', async () => {
-                            jest.resetModules();
-                            jest.doMock('../index/liveChatHelper', () =>
-                                jest.fn(() => ({
-                                    isLiveChatActive: () => {
-                                        return false;
-                                    }
-                                }))
-                            );
-
-                            // eslint-disable-next-line global-require
-                            app = require('../app');
-                            const response = await request(app).get('/chat');
-                            const actual = response.res.text.replace(/\s+/g, '');
-                            const pageHeading = `<h1 class="govuk-heading-xl">Sorry, the service is unavailable</h1>`.replace(
-                                /\s+/g,
-                                ''
-                            );
-                            expect(actual).toContain(pageHeading);
-                        });
-                    });
-                });
-            });
-            describe('/thisdoesntexist', () => {
-                describe('GET', () => {
-                    describe('200', () => {
-                        it('Should respond with a 200 status', async () => {
-                            const response = await request(app).get('/thisdoesntexist');
-                            expect(response.statusCode).toBe(200);
-                        });
-                        it('Should render a specific content on the page', async () => {
-                            const response = await request(app).get('/thisdoesntexist');
-                            const actual = response.res.text.replace(/\s+/g, '');
-                            const pageHeading = `<h1 class="govuk-heading-xl">Page not found</h1>`.replace(
-                                /\s+/g,
-                                ''
-                            );
-                            expect(actual).toContain(pageHeading);
-                        });
-                    });
-                });
+                // eslint-disable-next-line global-require
+                app = require('../app');
+                const response = await request(app).get('/start-chat');
+                const actual = response.res.text.replace(/\s+/g, '');
+                const pageHeading = `<h1 class="govuk-heading-xl">Sorry, the service is unavailable</h1>`.replace(
+                    /\s+/g,
+                    ''
+                );
+                expect(actual).toContain(pageHeading);
             });
         });
     });
 
-    describe('Cica-web /apply routes', () => {
-        describe('/', () => {
-            describe('GET', () => {
-                describe('302', () => {
-                    beforeAll(() => {
-                        setUpCommonMocks();
-                    });
+    describe('/chat', () => {
+        it('Should respond with a 200 status code', async () => {
+            const response = await request(app).get('/chat');
+            expect(response.statusCode).toBe(200);
+        });
+        describe('When Live Chat is active', () => {
+            it('Should render specific content on the page', async () => {
+                jest.resetModules();
+                jest.doMock('../index/liveChatHelper', () =>
+                    jest.fn(() => ({
+                        isLiveChatActive: () => {
+                            return true;
+                        }
+                    }))
+                );
 
-                    it('Should respond with a found status', () =>
-                        request
-                            .agent(app)
-                            .get('/apply/')
-                            .then(() =>
-                                request
-                                    .agent(app)
-                                    .get('/apply/')
-                                    .then(response => {
-                                        expect(response.statusCode).toBe(302);
-                                    })
-                            ));
-
-                    it('Should redirect the user', () =>
-                        request
-                            .agent(app)
-                            .get('/apply/')
-                            .then(response => {
-                                expect(response.res.text).toBe(
-                                    'Found. Redirecting to /apply/applicant-declaration'
-                                );
-                            }));
-
-                    it('Should redirect the user to the inital page if the requested page is selected without a session', () =>
-                        request
-                            .agent(app)
-                            .get('/apply/applicant-british-citizen-or-eu-national')
-                            .then(response => {
-                                expect(response.res.text).toBe(
-                                    'Found. Redirecting to /apply/applicant-declaration'
-                                );
-                            }));
-
-                    it('Should set a session cookie', () =>
-                        request
-                            .agent(app)
-                            .get('/apply/')
-                            .then(response => {
-                                let cookiePresent = false;
-                                const cookies = response.header['set-cookie'];
-                                cookies.forEach(cookie => {
-                                    cookiePresent = cookie.startsWith('session=')
-                                        ? true
-                                        : cookiePresent;
-                                });
-                                expect(cookiePresent).toBe(true);
-                            }));
-                });
-
-                describe('404', () => {
-                    it('Should fail gracefully if the questionnaire fails', () => {
-                        jest.resetModules();
-                        jest.doMock('../questionnaire/questionnaire-service', () =>
-                            jest.fn(() => ({
-                                createQuestionnaire: () => {
-                                    throw new Error();
-                                }
-                            }))
-                        );
-                        // eslint-disable-next-line global-require
-                        app = require('../app');
-                        replaceCsrfMiddlwareForTest(app);
-                        return request
-                            .agent(app)
-                            .get('/apply')
-                            .then(response => {
-                                expect(response.statusCode).toBe(404);
-                            });
-                    });
-
-                    it('Should fail gracefully', () => {
-                        jest.resetModules();
-                        jest.doMock('../questionnaire/questionnaire-service', () =>
-                            jest.fn(() => ({
-                                createQuestionnaire: () => createQuestionnaire,
-                                getFirstSection: () => {
-                                    throw new Error();
-                                }
-                            }))
-                        );
-                        // eslint-disable-next-line global-require
-                        app = require('../app');
-                        replaceCsrfMiddlwareForTest(app);
-                        const currentAgent = request.agent(app);
-                        return currentAgent.get('/apply').then(() =>
-                            currentAgent
-                                .get('/apply/')
-                                .set(
-                                    'Cookie',
-                                    'session=te3AFsfQozY49T4FIL8lEA.K2YvZ_eUm0YcCg2IA_qtCorcS2T17Td11LC0WmYuTaWc5PQuHcoCTHPuOPQoWVy_R5tUX4vzV4_pENOBxk1xPg0obdlP4suxaGK2YdqxjAE.1565864591496.900000.NwyQHlNP62CAiD-sk2GuuJvLzAQEZjX364hfnLp06yA;'
-                                )
-                                .then(response => {
-                                    expect(response.statusCode).toBe(404);
-                                })
-                        );
-                    });
-                });
+                // eslint-disable-next-line global-require
+                app = require('../app');
+                const response = await request(app).get('/chat');
+                const actual = response.res.text.replace(/\s+/g, '');
+                const pageContent = `<iframe id="chat-iframe"`.replace(/\s+/g, '');
+                expect(actual).toContain(pageContent);
             });
         });
+        describe('When Live Chat is not active', () => {
+            it('Should render specific content on the page', async () => {
+                jest.resetModules();
+                jest.doMock('../index/liveChatHelper', () =>
+                    jest.fn(() => ({
+                        isLiveChatActive: () => {
+                            return false;
+                        }
+                    }))
+                );
 
-        describe('/apply/:section', () => {
-            describe('GET', () => {
-                describe('200', () => {
-                    beforeAll(() => {
-                        const prefixedSection = 'p-applicant-enter-your-name';
-                        const initial = 'p-applicant-declaration';
-                        jest.resetModules();
-                        jest.doMock('../questionnaire/questionnaire-service', () =>
-                            jest.fn(() => ({
-                                getSection: () => getSectionValid,
-                                createQuestionnaire: () => createQuestionnaire,
-                                getCurrentSection: () => getCurrentSection
-                            }))
-                        );
-                        jest.doMock('../questionnaire/form-helper', () => ({
-                            addPrefix: () => prefixedSection,
-                            getSectionHtml: () => getSectionHtmlValid,
-                            removeSectionIdPrefix: () => initial,
-                            getSectionContext: () => undefined
-                        }));
-                        // eslint-disable-next-line global-require
-                        app = require('../app');
-                    });
-
-                    it('Should respond with a success status', () => {
-                        const currentAgent = request.agent(app);
-                        return currentAgent.get('/apply/').then(() =>
-                            currentAgent
-                                .get('/apply/applicant-enter-your-name')
-                                .set(
-                                    'Cookie',
-                                    'session=te3AFsfQozY49T4FIL8lEA.K2YvZ_eUm0YcCg2IA_qtCorcS2T17Td11LC0WmYuTaWc5PQuHcoCTHPuOPQoWVy_R5tUX4vzV4_pENOBxk1xPg0obdlP4suxaGK2YdqxjAE.1565864591496.900000.NwyQHlNP62CAiD-sk2GuuJvLzAQEZjX364hfnLp06yA;'
-                                )
-                                .then(response => {
-                                    expect(response.statusCode).toBe(200);
-                                })
-                        );
-                    });
-
-                    it('Should respond with a valid page', () => {
-                        const currentAgent = request.agent(app);
-                        return currentAgent.get('/apply').then(() =>
-                            currentAgent
-                                .get('/apply/applicant-enter-your-name')
-                                .set(
-                                    'Cookie',
-                                    'session=mzBCUTUQGsOT36H6Bvvy5w.D-Om63et1DE6qXBbDvSbsG9A-nw_jL29edAzRc74M7ELpS5am1meqsbNXr5eNhVjQip3H0dRWS9gyIua1h6SVxVPd8X-4BcV4K4RXwnzhEc.1565175346779.900000.4UB0eoITG2We5EDID3nrODqlVqqSzuV72tiJXuzreDg;'
-                                )
-                                .then(response => {
-                                    expect(response.res.text).toContain(
-                                        '<p>This is a valid page</p>'
-                                    );
-                                })
-                        );
-                    });
-                });
-
-                describe('404', () => {
-                    beforeAll(() => {
-                        const prefixedSection = 'p-applicant-enter-your-name';
-                        const initial = 'p-applicant-declaration';
-                        jest.resetModules();
-                        jest.doMock('../questionnaire/questionnaire-service', () =>
-                            jest.fn(() => ({
-                                getSection: () => getSectionValid,
-                                createQuestionnaire: () => createQuestionnaire,
-                                getCurrentSection: () => getCurrentSection
-                            }))
-                        );
-                        jest.doMock('../questionnaire/form-helper', () => ({
-                            addPrefix: () => prefixedSection,
-                            getSectionHtml: () => {
-                                throw new Error();
-                            },
-                            removeSectionIdPrefix: () => initial
-                        }));
-                        // eslint-disable-next-line global-require
-                        app = require('../app');
-                        replaceCsrfMiddlwareForTest(app);
-                    });
-
-                    it('Should fail gracefully', async () => {
-                        const currentAgent = request.agent(app);
-                        return currentAgent.get('/apply/').then(() => {
-                            formHelper.getSectionHtml = jest.fn(() => {
-                                throw new Error();
-                            });
-                            return currentAgent
-                                .get('/apply/applicant-enter-your-name')
-                                .set(
-                                    'Cookie',
-                                    'session=mzBCUTUQGsOT36H6Bvvy5w.D-Om63et1DE6qXBbDvSbsG9A-nw_jL29edAzRc74M7ELpS5am1meqsbNXr5eNhVjQip3H0dRWS9gyIua1h6SVxVPd8X-4BcV4K4RXwnzhEc.1565175346779.900000.4UB0eoITG2We5EDID3nrODqlVqqSzuV72tiJXuzreDg;'
-                                )
-                                .then(response => {
-                                    expect(response.statusCode).toBe(404);
-                                });
-                        });
-                    });
-                });
+                // eslint-disable-next-line global-require
+                app = require('../app');
+                const response = await request(app).get('/start-chat');
+                const actual = response.res.text.replace(/\s+/g, '');
+                const pageHeading = `<h1 class="govuk-heading-xl">Sorry, the service is unavailable</h1>`.replace(
+                    /\s+/g,
+                    ''
+                );
+                expect(actual).toContain(pageHeading);
             });
+        });
+    });
+});
 
-            describe('POST', () => {
-                describe('302', () => {
-                    describe('No errors', () => {
-                        beforeAll(() => {
-                            const prefixedSection = 'p-applicant-enter-your-name';
-                            const section = 'applicant-enter-your-name';
-                            const processedAnswer = {'q-applicant-title': 'Mr'};
-                            jest.resetModules();
-                            jest.doMock('../questionnaire/questionnaire-service', () =>
-                                jest.fn(() => ({
-                                    postSection: () => getProgressEntries,
-                                    createQuestionnaire: () => createQuestionnaire,
-                                    getCurrentSection: () => getCurrentSection
-                                }))
-                            );
-                            jest.doMock('../questionnaire/form-helper', () => ({
-                                addPrefix: () => prefixedSection,
-                                getSectionHtmlWithErrors: () => getSectionHtmlValid,
-                                removeSectionIdPrefix: () => section,
-                                processRequest: () => processedAnswer,
-                                getNextSection: () => section,
-                                getSectionContext: () => false
-                            }));
-                            // eslint-disable-next-line global-require
-                            app = require('../app');
-                            replaceCsrfMiddlwareForTest(app);
-                        });
+describe('/apply', () => {
+    beforeEach(() => {
+        setUpCommonMocks();
+    });
 
-                        it('Should respond with a found status if there are no errors', () => {
-                            const currentAgent = request.agent(app);
-                            return currentAgent.get('/apply/').then(() =>
-                                currentAgent
-                                    .post('/apply/applicant-enter-your-name')
-                                    .set(
-                                        'Cookie',
-                                        'session=te3AFsfQozY49T4FIL8lEA.K2YvZ_eUm0YcCg2IA_qtCorcS2T17Td11LC0WmYuTaWc5PQuHcoCTHPuOPQoWVy_R5tUX4vzV4_pENOBxk1xPg0obdlP4suxaGK2YdqxjAE.1565864591496.900000.NwyQHlNP62CAiD-sk2GuuJvLzAQEZjX364hfnLp06yA;'
-                                    )
-                                    .then(response => {
-                                        expect(response.statusCode).toBe(302);
-                                        expect(response.res.text).toBe(
-                                            'Found. Redirecting to /apply/applicant-enter-your-name'
-                                        );
-                                    })
-                            );
-                        });
+    it('Should respond with a redirection status', async () => {
+        const currentAgent = request.agent(app);
+        const response = await currentAgent.get('/apply');
+        expect(response.statusCode).toBe(302);
+    });
 
-                        it('Should redirect the user if there are no errors', () => {
-                            const currentAgent = request.agent(app);
-                            return currentAgent.get('/apply/').then(() =>
-                                currentAgent
-                                    .post('/apply/applicant-enter-your-name')
-                                    .set(
-                                        'Cookie',
-                                        'session=te3AFsfQozY49T4FIL8lEA.K2YvZ_eUm0YcCg2IA_qtCorcS2T17Td11LC0WmYuTaWc5PQuHcoCTHPuOPQoWVy_R5tUX4vzV4_pENOBxk1xPg0obdlP4suxaGK2YdqxjAE.1565864591496.900000.NwyQHlNP62CAiD-sk2GuuJvLzAQEZjX364hfnLp06yA;'
-                                    )
-                                    .then(response => {
-                                        expect(response.res.text).toBe(
-                                            'Found. Redirecting to /apply/applicant-enter-your-name'
-                                        );
-                                    })
-                            );
-                        });
-                    });
-                    describe('With errors', () => {
-                        beforeAll(() => {
-                            const prefixedSection = 'p-applicant-enter-your-name';
-                            const section = 'applicant-enter-your-name';
-                            const processedAnswer = {'q-applicant-title': 'Mr'};
-                            jest.resetModules();
-                            jest.doMock('../questionnaire/questionnaire-service', () =>
-                                jest.fn(() => ({
-                                    getSection: () => getSectionValid,
-                                    postSection: () => getProgressEntriesErrors,
-                                    createQuestionnaire: () => createQuestionnaire,
-                                    getCurrentSection: () => getCurrentSection
-                                }))
-                            );
-                            jest.doMock('../questionnaire/form-helper', () => ({
-                                addPrefix: () => prefixedSection,
-                                getSectionHtmlWithErrors: () => getSectionHtmlValid,
-                                removeSectionIdPrefix: () => section,
-                                processRequest: () => processedAnswer,
-                                getNextSection: () => section,
-                                getSectionHtml: () => getSectionHtmlValid
-                            }));
-                            // eslint-disable-next-line global-require
-                            app = require('../app');
-                            replaceCsrfMiddlwareForTest(app);
-                        });
+    it('Should redirect to the first section URL', async () => {
+        const currentAgent = request.agent(app);
+        const response = await currentAgent.get('/apply');
+        expect(response.res.text).toBe('Found. Redirecting to /apply/applicant-declaration');
+    });
 
-                        it('Should render the schema again with errors', () => {
-                            const currentAgent = request.agent(app);
-                            return currentAgent
-                                .get('/apply')
-                                .set(
-                                    'Cookie',
-                                    'session=te3AFsfQozY49T4FIL8lEA.K2YvZ_eUm0YcCg2IA_qtCorcS2T17Td11LC0WmYuTaWc5PQuHcoCTHPuOPQoWVy_R5tUX4vzV4_pENOBxk1xPg0obdlP4suxaGK2YdqxjAE.1565864591496.900000.NwyQHlNP62CAiD-sk2GuuJvLzAQEZjX364hfnLp06yA;'
-                                )
-                                .then(() =>
-                                    // get the csrf token...
-                                    currentAgent
-                                        .get('/apply/applicant-enter-your-name')
-                                        .set(
-                                            'Cookie',
-                                            'session=mzBCUTUQGsOT36H6Bvvy5w.D-Om63et1DE6qXBbDvSbsG9A-nw_jL29edAzRc74M7ELpS5am1meqsbNXr5eNhVjQip3H0dRWS9gyIua1h6SVxVPd8X-4BcV4K4RXwnzhEc.1565175346779.900000.4UB0eoITG2We5EDID3nrODqlVqqSzuV72tiJXuzreDg;'
-                                        )
-                                        .then(() =>
-                                            currentAgent
-                                                // then post to the page with the token.
-                                                .post('/apply/applicant-enter-your-name')
-                                                .send()
-                                                .then(response => {
-                                                    expect(response.res.text).toContain(
-                                                        '<p>This is a valid page</p>'
-                                                    );
-                                                })
-                                        )
-                                );
-                        });
-                    });
-                });
-                describe('404', () => {
-                    beforeAll(() => {
+    it('Should redirect the user to the inital page if the requested page is selected without a session', async () => {
+        const currentAgent = request.agent(app);
+        const response = await currentAgent.get('/apply/applicant-british-citizen-or-eu-national');
+        expect(response.res.text).toBe('Found. Redirecting to /apply/applicant-declaration');
+    });
+
+    it('Should set a session cookie', async () => {
+        let cookiePresent = false;
+        const currentAgent = request.agent(app);
+        const response = await currentAgent.get('/apply');
+        const cookies = response.header['set-cookie'];
+        cookies.forEach(cookie => {
+            cookiePresent = cookie.startsWith('cicaSession=') ? true : cookiePresent;
+        });
+        expect(cookiePresent).toBe(true);
+    });
+
+    describe('createQuestionnaire', () => {
+        it('Should fail gracefully', async () => {
+            function blockSpecificMocks() {
+                jest.doMock('../questionnaire/questionnaire-service', () =>
+                    jest.fn(() => ({
+                        createQuestionnaire: () => {
+                            return Promise.reject(new Error('Something went wrong'));
+                        },
+                        keepAlive: () => keepAlive
+                    }))
+                );
+            }
+            setUpCommonMocks(blockSpecificMocks);
+            const currentAgent = request.agent(app);
+            const response = await currentAgent.get('/apply');
+            expect(response.statusCode).toBe(404);
+        });
+    });
+
+    describe('getFirstSection', () => {
+        it('Should fail gracefully', async () => {
+            function blockSpecificMocks() {
+                jest.doMock('../questionnaire/questionnaire-service', () =>
+                    jest.fn(() => ({
+                        createQuestionnaire: () => createQuestionnaire,
+                        getFirstSection: () => {
+                            return Promise.reject(new Error('Something went wrong'));
+                        },
+                        keepAlive: () => keepAlive
+                    }))
+                );
+            }
+            setUpCommonMocks(blockSpecificMocks);
+
+            const currentAgent = request.agent(app);
+            await currentAgent
+                .get('/apply')
+                .set(
+                    'Cookie',
+                    'cicaSession=te3AFsfQozY49T4FIL8lEA.K2YvZ_eUm0YcCg2IA_qtCorcS2T17Td11LC0WmYuTaWc5PQuHcoCTHPuOPQoWVy_R5tUX4vzV4_pENOBxk1xPg0obdlP4suxaGK2YdqxjAE.1565864591496.900000.NwyQHlNP62CAiD-sk2GuuJvLzAQEZjX364hfnLp06yA;'
+                );
+            const response = await currentAgent.get('/apply');
+            expect(response.statusCode).toBe(404);
+        });
+    });
+
+    describe(':section', () => {
+        beforeEach(() => {
+            function blockSpecificMocks() {
+                const prefixedSection = 'p-applicant-enter-your-name';
+                const initial = 'p-applicant-declaration';
+                jest.doMock('../questionnaire/questionnaire-service', () =>
+                    jest.fn(() => ({
+                        getSection: () => getSectionValid,
+                        createQuestionnaire: () => createQuestionnaire,
+                        getCurrentSection: () => getCurrentSection,
+                        keepAlive: () => keepAlive
+                    }))
+                );
+                jest.doMock('../questionnaire/form-helper', () => ({
+                    addPrefix: () => prefixedSection,
+                    getSectionHtml: () => getSectionHtmlValid,
+                    removeSectionIdPrefix: () => initial,
+                    getSectionContext: () => undefined
+                }));
+            }
+            setUpCommonMocks(blockSpecificMocks);
+        });
+
+        it('Should respond with a 200 status code', async () => {
+            const currentAgent = request.agent(app);
+            await currentAgent.get('/apply');
+            const response = await currentAgent
+                .get('/apply/applicant-enter-your-name')
+                .set(
+                    'Cookie',
+                    'cicaSession=te3AFsfQozY49T4FIL8lEA.K2YvZ_eUm0YcCg2IA_qtCorcS2T17Td11LC0WmYuTaWc5PQuHcoCTHPuOPQoWVy_R5tUX4vzV4_pENOBxk1xPg0obdlP4suxaGK2YdqxjAE.1565864591496.900000.NwyQHlNP62CAiD-sk2GuuJvLzAQEZjX364hfnLp06yA;'
+                );
+            expect(response.statusCode).toBe(200);
+        });
+
+        it('Should respond with a valid page', async () => {
+            const currentAgent = request.agent(app);
+            await currentAgent.get('/apply');
+            const response = await currentAgent
+                .get('/apply/applicant-enter-your-name')
+                .set(
+                    'Cookie',
+                    'cicaSession=te3AFsfQozY49T4FIL8lEA.K2YvZ_eUm0YcCg2IA_qtCorcS2T17Td11LC0WmYuTaWc5PQuHcoCTHPuOPQoWVy_R5tUX4vzV4_pENOBxk1xPg0obdlP4suxaGK2YdqxjAE.1565864591496.900000.NwyQHlNP62CAiD-sk2GuuJvLzAQEZjX364hfnLp06yA;'
+                );
+            expect(response.res.text).toContain('<p>This is a valid page</p>');
+        });
+
+        describe('Post', () => {
+            describe('Redirects', () => {
+                beforeEach(() => {
+                    function blockSpecificMocks() {
                         const prefixedSection = 'p-applicant-enter-your-name';
                         const section = 'applicant-enter-your-name';
                         const processedAnswer = {'q-applicant-title': 'Mr'};
-                        jest.resetModules();
+                        jest.doMock('../questionnaire/questionnaire-service', () =>
+                            jest.fn(() => ({
+                                postSection: () => getProgressEntries,
+                                createQuestionnaire: () => createQuestionnaire,
+                                getCurrentSection: () => getCurrentSection,
+                                keepAlive: () => keepAlive
+                            }))
+                        );
+                        jest.doMock('../questionnaire/form-helper', () => ({
+                            addPrefix: () => prefixedSection,
+                            getSectionHtmlWithErrors: () => getSectionHtmlValid,
+                            removeSectionIdPrefix: () => section,
+                            processRequest: () => processedAnswer,
+                            getNextSection: () => section,
+                            getSectionContext: () => false
+                        }));
+                    }
+                    setUpCommonMocks(blockSpecificMocks);
+                });
+
+                it('Should respond with a redirection status code', async () => {
+                    const currentAgent = request.agent(app);
+                    await currentAgent.get('/apply/');
+                    const response = await currentAgent
+                        .post('/apply/applicant-enter-your-name')
+                        .set(
+                            'Cookie',
+                            'session=te3AFsfQozY49T4FIL8lEA.K2YvZ_eUm0YcCg2IA_qtCorcS2T17Td11LC0WmYuTaWc5PQuHcoCTHPuOPQoWVy_R5tUX4vzV4_pENOBxk1xPg0obdlP4suxaGK2YdqxjAE.1565864591496.900000.NwyQHlNP62CAiD-sk2GuuJvLzAQEZjX364hfnLp06yA;'
+                        );
+                    expect(response.statusCode).toBe(302);
+                });
+
+                it('Should redirect the user if there are no errors', async () => {
+                    const currentAgent = request.agent(app);
+                    await currentAgent.get('/apply/');
+                    const response = await currentAgent
+                        .post('/apply/applicant-enter-your-name')
+                        .set(
+                            'Cookie',
+                            'session=te3AFsfQozY49T4FIL8lEA.K2YvZ_eUm0YcCg2IA_qtCorcS2T17Td11LC0WmYuTaWc5PQuHcoCTHPuOPQoWVy_R5tUX4vzV4_pENOBxk1xPg0obdlP4suxaGK2YdqxjAE.1565864591496.900000.NwyQHlNP62CAiD-sk2GuuJvLzAQEZjX364hfnLp06yA;'
+                        );
+                    expect(response.statusCode).toBe(302);
+                    expect(response.res.text).toBe(
+                        'Found. Redirecting to /apply/applicant-enter-your-name'
+                    );
+                });
+            });
+
+            describe('Not Found', () => {
+                beforeEach(() => {
+                    function blockSpecificMocks() {
+                        const prefixedSection = 'p-applicant-enter-your-name';
+                        const section = 'applicant-enter-your-name';
+                        const processedAnswer = {'q-applicant-title': 'Mr'};
                         jest.doMock('../questionnaire/questionnaire-service', () =>
                             jest.fn(() => ({
                                 postSection: () => {
                                     throw new Error();
                                 },
                                 createQuestionnaire: () => createQuestionnaire,
-                                getCurrentSection: () => getCurrentSection
+                                getCurrentSection: () => getCurrentSection,
+                                keepAlive: () => keepAlive
                             }))
                         );
                         jest.doMock('../questionnaire/form-helper', () => ({
@@ -642,338 +499,282 @@ describe('Data capture service endpoints', () => {
                             processRequest: () => processedAnswer,
                             getNextSection: () => section
                         }));
-                        // eslint-disable-next-line global-require
-                        app = require('../app');
-                        replaceCsrfMiddlwareForTest(app);
-                    });
-
-                    it('Should fail gracefully', async () => {
-                        const currentAgent = request.agent(app);
-                        return currentAgent.get('/apply/').then(() => {
-                            formHelper.getSectionHtml = jest.fn(() => {
-                                throw new Error();
-                            });
-                            return currentAgent
-                                .post('/apply/applicant-enter-your-name')
-                                .set(
-                                    'Cookie',
-                                    'session=mzBCUTUQGsOT36H6Bvvy5w.D-Om63et1DE6qXBbDvSbsG9A-nw_jL29edAzRc74M7ELpS5am1meqsbNXr5eNhVjQip3H0dRWS9gyIua1h6SVxVPd8X-4BcV4K4RXwnzhEc.1565175346779.900000.4UB0eoITG2We5EDID3nrODqlVqqSzuV72tiJXuzreDg;'
-                                )
-                                .send()
-                                .then(response => {
-                                    expect(response.statusCode).toBe(404);
-                                });
-                        });
-                    });
-                });
-                describe('submission page success', () => {
-                    beforeAll(() => {
-                        const prefixedSection = 'p-applicant-declaration';
-                        const section = 'the-next-page';
-                        const processedAnswer = {'q-applicant-declaration': [true]};
-                        jest.resetModules();
-                        jest.doMock('../questionnaire/form-helper', () => ({
-                            addPrefix: () => prefixedSection,
-                            removeSectionIdPrefix: () => section,
-                            processRequest: () => processedAnswer,
-                            getSectionContext: () => 'submission'
-                        }));
-                        jest.doMock('../questionnaire/questionnaire-service', () =>
-                            jest.fn(() => ({
-                                postSubmission: () => {},
-                                postSection: () => getProgressEntries,
-                                createQuestionnaire: () => createQuestionnaire,
-                                getCurrentSection: () => getCurrentSection,
-                                getSubmissionStatus: () => postValidSubmission
-                            }))
-                        );
-                        // eslint-disable-next-line global-require
-                        app = require('../app');
-                        replaceCsrfMiddlwareForTest(app);
-                    });
-                    it('should submit the application', () => {
-                        const currentAgent = request.agent(app);
-                        return currentAgent.get('/apply/').then(() =>
-                            currentAgent
-                                .post('/apply/applicant-declaration')
-                                .set(
-                                    'Cookie',
-                                    'session=te3AFsfQozY49T4FIL8lEA.K2YvZ_eUm0YcCg2IA_qtCorcS2T17Td11LC0WmYuTaWc5PQuHcoCTHPuOPQoWVy_R5tUX4vzV4_pENOBxk1xPg0obdlP4suxaGK2YdqxjAE.1565864591496.900000.NwyQHlNP62CAiD-sk2GuuJvLzAQEZjX364hfnLp06yA;'
-                                )
-                                .then(response => {
-                                    expect(response.statusCode).toBe(302);
-                                    expect(response.res.text).toBe(
-                                        'Found. Redirecting to /apply/the-next-page'
-                                    );
-                                })
-                        );
-                    });
+                    }
+                    setUpCommonMocks(blockSpecificMocks);
                 });
 
-                describe('Submission page fail', () => {
-                    beforeAll(() => {
-                        const prefixedSection = 'p-applicant-declaration';
-                        const section = 'the-next-page';
-                        const processedAnswer = {'q-applicant-declaration': [true]};
-                        jest.resetModules();
-                        jest.doMock('../questionnaire/form-helper', () => ({
-                            addPrefix: () => prefixedSection,
-                            removeSectionIdPrefix: () => section,
-                            processRequest: () => processedAnswer,
-                            getSectionContext: () => 'submission'
-                        }));
-                        jest.doMock('../questionnaire/questionnaire-service', () =>
-                            jest.fn(() => ({
-                                postSubmission: () => {},
-                                postSection: () => getProgressEntries,
-                                createQuestionnaire: () => createQuestionnaire,
-                                getCurrentSection: () => getCurrentSection,
-                                getSubmissionStatus: () => postValidSubmissionServiceDown
-                            }))
-                        );
-                        // eslint-disable-next-line global-require
-                        app = require('../app');
-                        replaceCsrfMiddlwareForTest(app);
+                it('Should fail gracefully', async () => {
+                    const currentAgent = request.agent(app);
+                    formHelper.getSectionHtml = jest.fn(() => {
+                        throw new Error('Something went wrong');
                     });
-                    it('should fail gracefully if the application fails', () => {
-                        const currentAgent = request.agent(app);
-                        return currentAgent.get('/apply/').then(() =>
-                            currentAgent
-                                .post('/apply/applicant-declaration')
-                                .set(
-                                    'Cookie',
-                                    'session=te3AFsfQozY49T4FIL8lEA.K2YvZ_eUm0YcCg2IA_qtCorcS2T17Td11LC0WmYuTaWc5PQuHcoCTHPuOPQoWVy_R5tUX4vzV4_pENOBxk1xPg0obdlP4suxaGK2YdqxjAE.1565864591496.900000.NwyQHlNP62CAiD-sk2GuuJvLzAQEZjX364hfnLp06yA;'
-                                )
-                                .then(response => {
-                                    expect(response.statusCode).toBe(500);
-                                    expect(response.res.text).toContain(
-                                        '<p class="govuk-body">However, there is a delay with us sending your reference number to you.</p>'
-                                    );
-                                })
-                        );
-                    });
+                    await currentAgent.get('/apply/');
+                    const response = await currentAgent
+                        .post('/apply/applicant-enter-your-name')
+                        .set(
+                            'Cookie',
+                            'session=mzBCUTUQGsOT36H6Bvvy5w.D-Om63et1DE6qXBbDvSbsG9A-nw_jL29edAzRc74M7ELpS5am1meqsbNXr5eNhVjQip3H0dRWS9gyIua1h6SVxVPd8X-4BcV4K4RXwnzhEc.1565175346779.900000.4UB0eoITG2We5EDID3nrODqlVqqSzuV72tiJXuzreDg;'
+                        )
+                        .send();
+                    expect(response.statusCode).toBe(404);
                 });
             });
-        });
 
-        describe('/apply/previous/:section', () => {
-            describe('GET', () => {
-                describe('200', () => {
-                    describe('Given a sectionId', () => {
-                        beforeAll(() => {
-                            const prefixedSection = 'p-applicant-enter-your-name';
-                            const section = 'applicant-declaration';
-                            const processedAnswer = {'q-applicant-title': 'Mr'};
-                            jest.resetModules();
-                            jest.doMock('../questionnaire/questionnaire-service', () =>
-                                jest.fn(() => ({
-                                    getSection: () => getSectionValid,
-                                    postSection: () => getProgressEntries,
-                                    getPrevious: () => getPreviousValid,
-                                    createQuestionnaire: () => createQuestionnaire,
-                                    getCurrentSection: () => getCurrentSection
-                                }))
-                            );
+            describe('Submission', () => {
+                describe('Success', () => {
+                    beforeEach(() => {
+                        function blockSpecificMocks() {
+                            const prefixedSection = 'p-applicant-declaration';
+                            const section = 'the-next-page';
+                            const processedAnswer = {'q-applicant-declaration': [true]};
                             jest.doMock('../questionnaire/form-helper', () => ({
                                 addPrefix: () => prefixedSection,
                                 removeSectionIdPrefix: () => section,
-                                getSectionHtml: () => getSectionHtmlValid,
                                 processRequest: () => processedAnswer,
-                                getNextSection: () => section,
-                                getSectionContext: () => false
+                                getSectionContext: () => 'submission'
                             }));
-                            // eslint-disable-next-line global-require
-                            app = require('../app');
-                            replaceCsrfMiddlwareForTest(app);
-                        });
-                        it('Should redirect to a section', () => {
-                            const currentAgent = request.agent(app);
-                            return currentAgent.get('/apply/').then(() => {
-                                currentAgent
-                                    .get('/apply/previous/applicant-enter-your-name')
-                                    .set(
-                                        'Cookie',
-                                        'session=mzBCUTUQGsOT36H6Bvvy5w.D-Om63et1DE6qXBbDvSbsG9A-nw_jL29edAzRc74M7ELpS5am1meqsbNXr5eNhVjQip3H0dRWS9gyIua1h6SVxVPd8X-4BcV4K4RXwnzhEc.1565175346779.900000.4UB0eoITG2We5EDID3nrODqlVqqSzuV72tiJXuzreDg;'
-                                    )
-                                    .then(response => {
-                                        expect(response.statusCode).toBe(302);
-                                    });
-                            });
-                        });
-                        it('Should identify and render an external URL', () => {
-                            const currentAgent = request.agent(app);
-                            return currentAgent.get('/apply/').then(() =>
-                                currentAgent
-                                    .get('/apply/previous/applicant-enter-your-name')
-                                    .set(
-                                        'Cookie',
-                                        'session=mzBCUTUQGsOT36H6Bvvy5w.D-Om63et1DE6qXBbDvSbsG9A-nw_jL29edAzRc74M7ELpS5am1meqsbNXr5eNhVjQip3H0dRWS9gyIua1h6SVxVPd8X-4BcV4K4RXwnzhEc.1565175346779.900000.4UB0eoITG2We5EDID3nrODqlVqqSzuV72tiJXuzreDg;'
-                                    )
-                                    .then(() =>
-                                        // get the csrf token...
-                                        currentAgent
-                                            .get('/apply/applicant-enter-your-name')
-                                            .set(
-                                                'Cookie',
-                                                'session=mzBCUTUQGsOT36H6Bvvy5w.D-Om63et1DE6qXBbDvSbsG9A-nw_jL29edAzRc74M7ELpS5am1meqsbNXr5eNhVjQip3H0dRWS9gyIua1h6SVxVPd8X-4BcV4K4RXwnzhEc.1565175346779.900000.4UB0eoITG2We5EDID3nrODqlVqqSzuV72tiJXuzreDg;'
-                                            )
-                                            .then(() =>
-                                                currentAgent
-                                                    // then post to the page with the token.
-                                                    .post('/apply/applicant-enter-your-name')
-                                                    .send()
-                                                    .then(response => {
-                                                        expect(response.res.text).toBe(
-                                                            'Found. Redirecting to /apply/applicant-declaration'
-                                                        );
-                                                    })
-                                            )
-                                    )
-                            );
-                        });
-                    });
-
-                    describe('Given a URL', () => {
-                        beforeAll(() => {
-                            const prefixedSection = 'p-applicant-enter-your-name';
-                            const Section = 'applicant-declaration';
-                            jest.resetModules();
                             jest.doMock('../questionnaire/questionnaire-service', () =>
-                                // return a modified factory function, that returns an object with a method, that returns a valid created response
                                 jest.fn(() => ({
-                                    getPrevious: () => getPreviousValidUrl,
-                                    createQuestionnaire: () => createQuestionnaire
+                                    postSubmission: () => {},
+                                    postSection: () => getProgressEntries,
+                                    createQuestionnaire: () => createQuestionnaire,
+                                    getCurrentSection: () => getCurrentSection,
+                                    getSubmissionStatus: () => postValidSubmission,
+                                    keepAlive: () => keepAlive
                                 }))
                             );
-                            jest.doMock('../questionnaire/form-helper', () => ({
-                                addPrefix: () => prefixedSection,
-                                removeSectionIdPrefix: () => Section
-                            }));
-                            // eslint-disable-next-line global-require
-                            app = require('../app');
-                            replaceCsrfMiddlwareForTest(app);
-                        });
-                        it('Should respond with a found status', () => {
-                            const currentAgent = request.agent(app);
-                            return currentAgent.get('/apply/').then(() =>
-                                currentAgent
-                                    .get('/apply/previous/applicant-enter-your-name')
-                                    .set(
-                                        'Cookie',
-                                        'session=mzBCUTUQGsOT36H6Bvvy5w.D-Om63et1DE6qXBbDvSbsG9A-nw_jL29edAzRc74M7ELpS5am1meqsbNXr5eNhVjQip3H0dRWS9gyIua1h6SVxVPd8X-4BcV4K4RXwnzhEc.1565175346779.900000.4UB0eoITG2We5EDID3nrODqlVqqSzuV72tiJXuzreDg;'
-                                    )
-                                    .then(response => {
-                                        expect(response.statusCode).toBe(302);
-                                    })
-                            );
-                        });
-                        it('Should redirect the user', () => {
-                            const currentAgent = request.agent(app);
-                            return currentAgent.get('/apply/').then(() =>
-                                currentAgent
-                                    .get('/apply/previous/applicant-enter-your-name')
-                                    .set(
-                                        'Cookie',
-                                        'session=mzBCUTUQGsOT36H6Bvvy5w.D-Om63et1DE6qXBbDvSbsG9A-nw_jL29edAzRc74M7ELpS5am1meqsbNXr5eNhVjQip3H0dRWS9gyIua1h6SVxVPd8X-4BcV4K4RXwnzhEc.1565175346779.900000.4UB0eoITG2We5EDID3nrODqlVqqSzuV72tiJXuzreDg;'
-                                    )
-                                    .then(response => {
-                                        expect(response.res.text).toBe(
-                                            'Found. Redirecting to http://www.google.com/'
-                                        );
-                                    })
-                            );
-                        });
-                    });
-                });
-                describe('404', () => {
-                    it('Should fail gracefully', () => {
-                        jest.resetModules();
-                        jest.doMock('../questionnaire/questionnaire-service', () =>
-                            // return a modified factory function, that returns an object with a method, that returns a valid created response
-                            jest.fn(() => ({
-                                createQuestionnaire: () => createQuestionnaire,
-                                getPrevious() {
-                                    const err = Error(`The page was not found`);
-                                    err.name = 'HTTPError';
-                                    err.statusCode = 404;
-                                    err.error = '404 Not Found';
-                                    throw err;
-                                }
-                            }))
-                        );
-                        // eslint-disable-next-line global-require
-                        app = require('../app');
-                        replaceCsrfMiddlwareForTest(app);
-                        const currentAgent = request.agent(app);
-                        return currentAgent.get('/apply/').then(() => {
-                            formHelper.removeSectionIdPrefix = jest.fn(
-                                () => 'applicant-declaration'
-                            );
-                            return currentAgent
-                                .get('/apply/previous/applicant-enter-your-name')
-                                .set(
-                                    'Cookie',
-                                    'session=mzBCUTUQGsOT36H6Bvvy5w.D-Om63et1DE6qXBbDvSbsG9A-nw_jL29edAzRc74M7ELpS5am1meqsbNXr5eNhVjQip3H0dRWS9gyIua1h6SVxVPd8X-4BcV4K4RXwnzhEc.1565175346779.900000.4UB0eoITG2We5EDID3nrODqlVqqSzuV72tiJXuzreDg;'
-                                )
-                                .then(response => {
-                                    expect(response.statusCode).toBe(404);
-                                });
-                        });
+                        }
+                        setUpCommonMocks(blockSpecificMocks);
                     });
 
-                    it('Should default to a 404 error is no status code is provided.', () => {
-                        jest.resetModules();
-                        jest.doMock('../questionnaire/questionnaire-service', () =>
-                            // return a modified factory function, that returns an object with a method, that returns a valid created response
-                            jest.fn(() => ({
-                                createQuestionnaire: () => createQuestionnaire,
-                                getPrevious() {
-                                    throw new Error();
-                                }
-                            }))
-                        );
-                        // eslint-disable-next-line global-require
-                        app = require('../app');
-                        replaceCsrfMiddlwareForTest(app);
+                    it('Should submit the application', async () => {
                         const currentAgent = request.agent(app);
-                        return currentAgent.get('/apply/').then(() => {
-                            formHelper.removeSectionIdPrefix = jest.fn(
-                                () => 'applicant-declaration'
+                        await currentAgent.get('/apply/');
+                        const response = await currentAgent
+                            .post('/apply/applicant-declaration')
+                            .set(
+                                'Cookie',
+                                'session=te3AFsfQozY49T4FIL8lEA.K2YvZ_eUm0YcCg2IA_qtCorcS2T17Td11LC0WmYuTaWc5PQuHcoCTHPuOPQoWVy_R5tUX4vzV4_pENOBxk1xPg0obdlP4suxaGK2YdqxjAE.1565864591496.900000.NwyQHlNP62CAiD-sk2GuuJvLzAQEZjX364hfnLp06yA;'
                             );
-                            return currentAgent
-                                .get('/apply/previous/applicant-enter-your-name')
-                                .set(
-                                    'Cookie',
-                                    'session=mzBCUTUQGsOT36H6Bvvy5w.D-Om63et1DE6qXBbDvSbsG9A-nw_jL29edAzRc74M7ELpS5am1meqsbNXr5eNhVjQip3H0dRWS9gyIua1h6SVxVPd8X-4BcV4K4RXwnzhEc.1565175346779.900000.4UB0eoITG2We5EDID3nrODqlVqqSzuV72tiJXuzreDg;'
-                                )
-                                .then(response => {
-                                    expect(response.statusCode).toBe(404);
-                                });
-                        });
+                        expect(response.statusCode).toBe(302);
+                        expect(response.res.text).toBe(
+                            'Found. Redirecting to /apply/the-next-page'
+                        );
+                    });
+                });
+
+                describe('Failure', () => {
+                    beforeEach(() => {
+                        function blockSpecificMocks() {
+                            const prefixedSection = 'p-applicant-declaration';
+                            const section = 'the-next-page';
+                            const processedAnswer = {'q-applicant-declaration': [true]};
+                            jest.doMock('../questionnaire/form-helper', () => ({
+                                addPrefix: () => prefixedSection,
+                                removeSectionIdPrefix: () => section,
+                                processRequest: () => processedAnswer,
+                                getSectionContext: () => 'submission'
+                            }));
+                            jest.doMock('../questionnaire/questionnaire-service', () =>
+                                jest.fn(() => ({
+                                    postSubmission: () => {},
+                                    postSection: () => getProgressEntries,
+                                    createQuestionnaire: () => createQuestionnaire,
+                                    getCurrentSection: () => getCurrentSection,
+                                    getSubmissionStatus: () => postValidSubmissionServiceDown,
+                                    keepAlive: () => keepAlive
+                                }))
+                            );
+                        }
+                        setUpCommonMocks(blockSpecificMocks);
+                    });
+
+                    it('Should submit the application', async () => {
+                        const currentAgent = request.agent(app);
+                        await currentAgent.get('/apply/');
+                        const response = await currentAgent
+                            .post('/apply/applicant-declaration')
+                            .set(
+                                'Cookie',
+                                'session=te3AFsfQozY49T4FIL8lEA.K2YvZ_eUm0YcCg2IA_qtCorcS2T17Td11LC0WmYuTaWc5PQuHcoCTHPuOPQoWVy_R5tUX4vzV4_pENOBxk1xPg0obdlP4suxaGK2YdqxjAE.1565864591496.900000.NwyQHlNP62CAiD-sk2GuuJvLzAQEZjX364hfnLp06yA;'
+                            );
+                        expect(response.statusCode).toBe(500);
+                        expect(response.res.text).toContain(
+                            '<p class="govuk-body">However, there is a delay with us sending your reference number to you.</p>'
+                        );
                     });
                 });
             });
         });
+    });
 
-        describe('/apply/:section?next=<some section id>', () => {
+    describe('/previous/:section', () => {
+        describe('Given a sectionId', () => {
             beforeEach(() => {
-                // tidy up from previous tests
-                jest.resetModules();
-                jest.unmock('../questionnaire/questionnaire-service');
-                jest.unmock('../questionnaire/form-helper');
-                jest.unmock('client-sessions');
+                function blockSpecificMocks() {
+                    const prefixedSection = 'p-applicant-enter-your-name';
+                    const section = 'applicant-declaration';
+                    const processedAnswer = {'q-applicant-title': 'Mr'};
+                    jest.doMock('../questionnaire/questionnaire-service', () =>
+                        jest.fn(() => ({
+                            getSection: () => getSectionValid,
+                            postSection: () => getProgressEntries,
+                            getPrevious: () => getPreviousValid,
+                            createQuestionnaire: () => createQuestionnaire,
+                            getCurrentSection: () => getCurrentSection,
+                            keepAlive: () => keepAlive
+                        }))
+                    );
+                    jest.doMock('../questionnaire/form-helper', () => ({
+                        addPrefix: () => prefixedSection,
+                        removeSectionIdPrefix: () => section,
+                        getSectionHtml: () => getSectionHtmlValid,
+                        processRequest: () => processedAnswer,
+                        getNextSection: () => section,
+                        getSectionContext: () => false
+                    }));
+                }
+                setUpCommonMocks(blockSpecificMocks);
+            });
 
-                // mock cookie
-                jest.doMock('client-sessions', () => () => (req, res, next) => {
+            it('Should redirect to a section', async () => {
+                const currentAgent = request.agent(app);
+                const response = await currentAgent
+                    .get('/apply/previous/applicant-enter-your-name')
+                    .set(
+                        'Cookie',
+                        'session=mzBCUTUQGsOT36H6Bvvy5w.D-Om63et1DE6qXBbDvSbsG9A-nw_jL29edAzRc74M7ELpS5am1meqsbNXr5eNhVjQip3H0dRWS9gyIua1h6SVxVPd8X-4BcV4K4RXwnzhEc.1565175346779.900000.4UB0eoITG2We5EDID3nrODqlVqqSzuV72tiJXuzreDg;'
+                    );
+                expect(response.statusCode).toBe(302);
+            });
+
+            it('Should identify and render an external URL', async () => {
+                const currentAgent = request.agent(app);
+                const response = await currentAgent
+                    .get('/apply/previous/applicant-enter-your-name')
+                    .set(
+                        'Cookie',
+                        'cicaSession=mzBCUTUQGsOT36H6Bvvy5w.D-Om63et1DE6qXBbDvSbsG9A-nw_jL29edAzRc74M7ELpS5am1meqsbNXr5eNhVjQip3H0dRWS9gyIua1h6SVxVPd8X-4BcV4K4RXwnzhEc.1565175346779.900000.4UB0eoITG2We5EDID3nrODqlVqqSzuV72tiJXuzreDg;'
+                    );
+                expect(response.res.text).toBe(
+                    'Found. Redirecting to /apply/applicant-declaration'
+                );
+            });
+        });
+
+        describe('Given a URL', () => {
+            beforeEach(() => {
+                function blockSpecificMocks() {
+                    const prefixedSection = 'p-applicant-enter-your-name';
+                    const Section = 'applicant-declaration';
+                    jest.doMock('../questionnaire/questionnaire-service', () =>
+                        jest.fn(() => ({
+                            getPrevious: () => getPreviousValidUrl,
+                            createQuestionnaire: () => createQuestionnaire,
+                            keepAlive: () => keepAlive
+                        }))
+                    );
+                    jest.doMock('../questionnaire/form-helper', () => ({
+                        addPrefix: () => prefixedSection,
+                        removeSectionIdPrefix: () => Section
+                    }));
+                }
+                setUpCommonMocks(blockSpecificMocks);
+            });
+
+            it('Should redirect the request', async () => {
+                const currentAgent = request.agent(app);
+                await currentAgent.get('/apply/');
+                const response = await currentAgent
+                    .get('/apply/previous/applicant-enter-your-name')
+                    .set(
+                        'Cookie',
+                        'session=mzBCUTUQGsOT36H6Bvvy5w.D-Om63et1DE6qXBbDvSbsG9A-nw_jL29edAzRc74M7ELpS5am1meqsbNXr5eNhVjQip3H0dRWS9gyIua1h6SVxVPd8X-4BcV4K4RXwnzhEc.1565175346779.900000.4UB0eoITG2We5EDID3nrODqlVqqSzuV72tiJXuzreDg;'
+                    );
+                expect(response.statusCode).toBe(302);
+            });
+
+            it('Should redirect to a page', async () => {
+                const currentAgent = request.agent(app);
+                await currentAgent.get('/apply/');
+                const response = await currentAgent
+                    .get('/apply/previous/applicant-enter-your-name')
+                    .set(
+                        'Cookie',
+                        'session=mzBCUTUQGsOT36H6Bvvy5w.D-Om63et1DE6qXBbDvSbsG9A-nw_jL29edAzRc74M7ELpS5am1meqsbNXr5eNhVjQip3H0dRWS9gyIua1h6SVxVPd8X-4BcV4K4RXwnzhEc.1565175346779.900000.4UB0eoITG2We5EDID3nrODqlVqqSzuV72tiJXuzreDg;'
+                    );
+                expect(response.res.text).toBe('Found. Redirecting to http://www.google.com/');
+            });
+        });
+
+        describe('Error', () => {
+            it('Should fail gracefully', async () => {
+                function blockSpecificMocks() {
+                    jest.doMock('../questionnaire/questionnaire-service', () =>
+                        jest.fn(() => ({
+                            createQuestionnaire: () => createQuestionnaire,
+                            getPrevious() {
+                                const err = Error(`The page was not found`);
+                                err.name = 'HTTPError';
+                                err.statusCode = 404;
+                                err.error = '404 Not Found';
+                                throw err;
+                            },
+                            keepAlive: () => keepAlive
+                        }))
+                    );
+                }
+                setUpCommonMocks(blockSpecificMocks);
+                const currentAgent = request.agent(app);
+                await currentAgent.get('/apply/');
+                formHelper.removeSectionIdPrefix = jest.fn(() => 'applicant-declaration');
+                const response = await currentAgent
+                    .get('/apply/previous/applicant-enter-your-name')
+                    .set(
+                        'Cookie',
+                        'session=mzBCUTUQGsOT36H6Bvvy5w.D-Om63et1DE6qXBbDvSbsG9A-nw_jL29edAzRc74M7ELpS5am1meqsbNXr5eNhVjQip3H0dRWS9gyIua1h6SVxVPd8X-4BcV4K4RXwnzhEc.1565175346779.900000.4UB0eoITG2We5EDID3nrODqlVqqSzuV72tiJXuzreDg;'
+                    );
+                expect(response.statusCode).toBe(404);
+            });
+            it('Should default to 404 if no error code is provided', async () => {
+                function blockSpecificMocks() {
+                    jest.doMock('../questionnaire/questionnaire-service', () =>
+                        jest.fn(() => ({
+                            createQuestionnaire: () => createQuestionnaire,
+                            getPrevious: () => {
+                                return Promise.reject(new Error('Something went wrong'));
+                            },
+                            keepAlive: () => keepAlive
+                        }))
+                    );
+                }
+                setUpCommonMocks(blockSpecificMocks);
+                const currentAgent = request.agent(app);
+                await currentAgent.get('/apply/');
+                formHelper.removeSectionIdPrefix = jest.fn(() => 'applicant-declaration');
+                const response = await currentAgent
+                    .get('/apply/previous/applicant-enter-your-name')
+                    .set(
+                        'Cookie',
+                        'session=mzBCUTUQGsOT36H6Bvvy5w.D-Om63et1DE6qXBbDvSbsG9A-nw_jL29edAzRc74M7ELpS5am1meqsbNXr5eNhVjQip3H0dRWS9gyIua1h6SVxVPd8X-4BcV4K4RXwnzhEc.1565175346779.900000.4UB0eoITG2We5EDID3nrODqlVqqSzuV72tiJXuzreDg;'
+                    );
+                expect(response.statusCode).toBe(404);
+            });
+        });
+    });
+
+    describe('/apply/:section?next=<some section id>', () => {
+        it('Should redirect to the prescribed next section id if available', async () => {
+            function blockSpecificMocks() {
+                jest.doMock('express-session', () => () => (req, res, next) => {
                     req.session = {
+                        cookie: {},
                         questionnaireId: 'c7f3b592-b7ac-4f2a-ab9c-8af407ade8cd'
                     };
 
                     next();
                 });
-            });
 
-            it('should redirect to the prescribed next section id if available', async () => {
                 jest.doMock('../questionnaire/request-service', () => {
                     const api = `${process.env.CW_DCS_URL}/api/v1/questionnaires/c7f3b592-b7ac-4f2a-ab9c-8af407ade8cd`;
 
@@ -1000,6 +801,10 @@ describe('Data capture service endpoints', () => {
                                             }
                                         ]
                                     }
+                                },
+                                [`${api}/session/keep-alive`]: {
+                                    statusCode: 200,
+                                    ...keepAlive
                                 }
                             };
 
@@ -1007,20 +812,28 @@ describe('Data capture service endpoints', () => {
                         }
                     });
                 });
+            }
+            setUpCommonMocks(blockSpecificMocks);
 
-                // eslint-disable-next-line global-require
-                app = require('../app');
-                replaceCsrfMiddlwareForTest(app);
+            const response = await request(app).post(
+                '/apply/applicant-enter-your-name?next=check-your-answers'
+            );
 
-                const response = await request(app).post(
-                    '/apply/applicant-enter-your-name?next=check-your-answers'
-                );
+            expect(response.statusCode).toBe(302);
+            expect(response.res.text).toBe('Found. Redirecting to /apply/check-your-answers');
+        });
 
-                expect(response.statusCode).toBe(302);
-                expect(response.res.text).toBe('Found. Redirecting to /apply/check-your-answers');
-            });
+        it('Should redirect to the current section if the prescribed next section id is not available', async () => {
+            function blockSpecificMocks() {
+                jest.doMock('express-session', () => () => (req, res, next) => {
+                    req.session = {
+                        cookie: {},
+                        questionnaireId: 'c7f3b592-b7ac-4f2a-ab9c-8af407ade8cd'
+                    };
 
-            it('should redirect to the current section if the prescribed next section id is not available', async () => {
+                    next();
+                });
+
                 jest.doMock('../questionnaire/request-service', () => {
                     const api = `${process.env.CW_DCS_URL}/api/v1/questionnaires/c7f3b592-b7ac-4f2a-ab9c-8af407ade8cd`;
 
@@ -1051,6 +864,10 @@ describe('Data capture service endpoints', () => {
                                             }
                                         ]
                                     }
+                                },
+                                [`${api}/session/keep-alive`]: {
+                                    statusCode: 200,
+                                    ...keepAlive
                                 }
                             };
 
@@ -1058,19 +875,19 @@ describe('Data capture service endpoints', () => {
                         }
                     });
                 });
-                // eslint-disable-next-line global-require
-                app = require('../app');
-                replaceCsrfMiddlwareForTest(app);
+            }
+            setUpCommonMocks(blockSpecificMocks);
 
-                const response = await request(app).post(
-                    '/apply/applicant-are-you-18-or-over?next=check-your-answers'
-                );
+            const currentAgent = request.agent(app);
+            await currentAgent.get('/apply/');
+            const response = await currentAgent.post(
+                '/apply/applicant-are-you-18-or-over?next=check-your-answers'
+            );
 
-                expect(response.statusCode).toBe(302);
-                expect(response.res.text).toBe(
-                    'Found. Redirecting to /apply/applicant-redirect-to-our-other-application'
-                );
-            });
+            expect(response.statusCode).toBe(302);
+            expect(response.res.text).toBe(
+                'Found. Redirecting to /apply/applicant-redirect-to-our-other-application'
+            );
         });
     });
 });
@@ -1150,6 +967,13 @@ describe('/session', () => {
                 );
             }
             setUpCommonMocks(blockSpecificMocks);
+        });
+
+        it('should error when retreiving a session resource', async () => {
+            const currentAgent = request.agent(app);
+            await currentAgent.get('/apply');
+            const response = await currentAgent.get('/session');
+            expect(response.statusCode).toBe(404);
         });
 
         it('should error when retreiving a session keep alive resource', async () => {

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -44,7 +44,7 @@ function replaceCsrfMiddlwareForTest(expressApp) {
 
     const csrfProtection = csrf({
         cookie: false,
-        sessionKey: 'cicaSession',
+        sessionKey: 'session',
         ignoreMethods: ['GET', 'POST']
     });
     expressApp.use(csrfProtection);
@@ -331,7 +331,7 @@ describe('Data capture service endpoints', () => {
                                 );
                             }));
 
-                    it('Should set a cicaSession cookie', () =>
+                    it('Should set a session cookie', () =>
                         request
                             .agent(app)
                             .get('/apply/')
@@ -339,7 +339,7 @@ describe('Data capture service endpoints', () => {
                                 let cookiePresent = false;
                                 const cookies = response.header['set-cookie'];
                                 cookies.forEach(cookie => {
-                                    cookiePresent = cookie.startsWith('cicaSession=')
+                                    cookiePresent = cookie.startsWith('session=')
                                         ? true
                                         : cookiePresent;
                                 });
@@ -387,7 +387,7 @@ describe('Data capture service endpoints', () => {
                                 .get('/apply/')
                                 .set(
                                     'Cookie',
-                                    'cicaSession=te3AFsfQozY49T4FIL8lEA.K2YvZ_eUm0YcCg2IA_qtCorcS2T17Td11LC0WmYuTaWc5PQuHcoCTHPuOPQoWVy_R5tUX4vzV4_pENOBxk1xPg0obdlP4suxaGK2YdqxjAE.1565864591496.900000.NwyQHlNP62CAiD-sk2GuuJvLzAQEZjX364hfnLp06yA;'
+                                    'session=te3AFsfQozY49T4FIL8lEA.K2YvZ_eUm0YcCg2IA_qtCorcS2T17Td11LC0WmYuTaWc5PQuHcoCTHPuOPQoWVy_R5tUX4vzV4_pENOBxk1xPg0obdlP4suxaGK2YdqxjAE.1565864591496.900000.NwyQHlNP62CAiD-sk2GuuJvLzAQEZjX364hfnLp06yA;'
                                 )
                                 .then(response => {
                                     expect(response.statusCode).toBe(404);
@@ -429,7 +429,7 @@ describe('Data capture service endpoints', () => {
                                 .get('/apply/applicant-enter-your-name')
                                 .set(
                                     'Cookie',
-                                    'cicaSession=te3AFsfQozY49T4FIL8lEA.K2YvZ_eUm0YcCg2IA_qtCorcS2T17Td11LC0WmYuTaWc5PQuHcoCTHPuOPQoWVy_R5tUX4vzV4_pENOBxk1xPg0obdlP4suxaGK2YdqxjAE.1565864591496.900000.NwyQHlNP62CAiD-sk2GuuJvLzAQEZjX364hfnLp06yA;'
+                                    'session=te3AFsfQozY49T4FIL8lEA.K2YvZ_eUm0YcCg2IA_qtCorcS2T17Td11LC0WmYuTaWc5PQuHcoCTHPuOPQoWVy_R5tUX4vzV4_pENOBxk1xPg0obdlP4suxaGK2YdqxjAE.1565864591496.900000.NwyQHlNP62CAiD-sk2GuuJvLzAQEZjX364hfnLp06yA;'
                                 )
                                 .then(response => {
                                     expect(response.statusCode).toBe(200);
@@ -444,7 +444,7 @@ describe('Data capture service endpoints', () => {
                                 .get('/apply/applicant-enter-your-name')
                                 .set(
                                     'Cookie',
-                                    'cicaSession=mzBCUTUQGsOT36H6Bvvy5w.D-Om63et1DE6qXBbDvSbsG9A-nw_jL29edAzRc74M7ELpS5am1meqsbNXr5eNhVjQip3H0dRWS9gyIua1h6SVxVPd8X-4BcV4K4RXwnzhEc.1565175346779.900000.4UB0eoITG2We5EDID3nrODqlVqqSzuV72tiJXuzreDg;'
+                                    'session=mzBCUTUQGsOT36H6Bvvy5w.D-Om63et1DE6qXBbDvSbsG9A-nw_jL29edAzRc74M7ELpS5am1meqsbNXr5eNhVjQip3H0dRWS9gyIua1h6SVxVPd8X-4BcV4K4RXwnzhEc.1565175346779.900000.4UB0eoITG2We5EDID3nrODqlVqqSzuV72tiJXuzreDg;'
                                 )
                                 .then(response => {
                                     expect(response.res.text).toContain(
@@ -489,7 +489,7 @@ describe('Data capture service endpoints', () => {
                                 .get('/apply/applicant-enter-your-name')
                                 .set(
                                     'Cookie',
-                                    'cicaSession=mzBCUTUQGsOT36H6Bvvy5w.D-Om63et1DE6qXBbDvSbsG9A-nw_jL29edAzRc74M7ELpS5am1meqsbNXr5eNhVjQip3H0dRWS9gyIua1h6SVxVPd8X-4BcV4K4RXwnzhEc.1565175346779.900000.4UB0eoITG2We5EDID3nrODqlVqqSzuV72tiJXuzreDg;'
+                                    'session=mzBCUTUQGsOT36H6Bvvy5w.D-Om63et1DE6qXBbDvSbsG9A-nw_jL29edAzRc74M7ELpS5am1meqsbNXr5eNhVjQip3H0dRWS9gyIua1h6SVxVPd8X-4BcV4K4RXwnzhEc.1565175346779.900000.4UB0eoITG2We5EDID3nrODqlVqqSzuV72tiJXuzreDg;'
                                 )
                                 .then(response => {
                                     expect(response.statusCode).toBe(404);
@@ -534,7 +534,7 @@ describe('Data capture service endpoints', () => {
                                     .post('/apply/applicant-enter-your-name')
                                     .set(
                                         'Cookie',
-                                        'cicaSession=te3AFsfQozY49T4FIL8lEA.K2YvZ_eUm0YcCg2IA_qtCorcS2T17Td11LC0WmYuTaWc5PQuHcoCTHPuOPQoWVy_R5tUX4vzV4_pENOBxk1xPg0obdlP4suxaGK2YdqxjAE.1565864591496.900000.NwyQHlNP62CAiD-sk2GuuJvLzAQEZjX364hfnLp06yA;'
+                                        'session=te3AFsfQozY49T4FIL8lEA.K2YvZ_eUm0YcCg2IA_qtCorcS2T17Td11LC0WmYuTaWc5PQuHcoCTHPuOPQoWVy_R5tUX4vzV4_pENOBxk1xPg0obdlP4suxaGK2YdqxjAE.1565864591496.900000.NwyQHlNP62CAiD-sk2GuuJvLzAQEZjX364hfnLp06yA;'
                                     )
                                     .then(response => {
                                         expect(response.statusCode).toBe(302);
@@ -552,7 +552,7 @@ describe('Data capture service endpoints', () => {
                                     .post('/apply/applicant-enter-your-name')
                                     .set(
                                         'Cookie',
-                                        'cicaSession=te3AFsfQozY49T4FIL8lEA.K2YvZ_eUm0YcCg2IA_qtCorcS2T17Td11LC0WmYuTaWc5PQuHcoCTHPuOPQoWVy_R5tUX4vzV4_pENOBxk1xPg0obdlP4suxaGK2YdqxjAE.1565864591496.900000.NwyQHlNP62CAiD-sk2GuuJvLzAQEZjX364hfnLp06yA;'
+                                        'session=te3AFsfQozY49T4FIL8lEA.K2YvZ_eUm0YcCg2IA_qtCorcS2T17Td11LC0WmYuTaWc5PQuHcoCTHPuOPQoWVy_R5tUX4vzV4_pENOBxk1xPg0obdlP4suxaGK2YdqxjAE.1565864591496.900000.NwyQHlNP62CAiD-sk2GuuJvLzAQEZjX364hfnLp06yA;'
                                     )
                                     .then(response => {
                                         expect(response.res.text).toBe(
@@ -595,7 +595,7 @@ describe('Data capture service endpoints', () => {
                                 .get('/apply')
                                 .set(
                                     'Cookie',
-                                    'cicaSession=te3AFsfQozY49T4FIL8lEA.K2YvZ_eUm0YcCg2IA_qtCorcS2T17Td11LC0WmYuTaWc5PQuHcoCTHPuOPQoWVy_R5tUX4vzV4_pENOBxk1xPg0obdlP4suxaGK2YdqxjAE.1565864591496.900000.NwyQHlNP62CAiD-sk2GuuJvLzAQEZjX364hfnLp06yA;'
+                                    'session=te3AFsfQozY49T4FIL8lEA.K2YvZ_eUm0YcCg2IA_qtCorcS2T17Td11LC0WmYuTaWc5PQuHcoCTHPuOPQoWVy_R5tUX4vzV4_pENOBxk1xPg0obdlP4suxaGK2YdqxjAE.1565864591496.900000.NwyQHlNP62CAiD-sk2GuuJvLzAQEZjX364hfnLp06yA;'
                                 )
                                 .then(() =>
                                     // get the csrf token...
@@ -603,7 +603,7 @@ describe('Data capture service endpoints', () => {
                                         .get('/apply/applicant-enter-your-name')
                                         .set(
                                             'Cookie',
-                                            'cicaSession=mzBCUTUQGsOT36H6Bvvy5w.D-Om63et1DE6qXBbDvSbsG9A-nw_jL29edAzRc74M7ELpS5am1meqsbNXr5eNhVjQip3H0dRWS9gyIua1h6SVxVPd8X-4BcV4K4RXwnzhEc.1565175346779.900000.4UB0eoITG2We5EDID3nrODqlVqqSzuV72tiJXuzreDg;'
+                                            'session=mzBCUTUQGsOT36H6Bvvy5w.D-Om63et1DE6qXBbDvSbsG9A-nw_jL29edAzRc74M7ELpS5am1meqsbNXr5eNhVjQip3H0dRWS9gyIua1h6SVxVPd8X-4BcV4K4RXwnzhEc.1565175346779.900000.4UB0eoITG2We5EDID3nrODqlVqqSzuV72tiJXuzreDg;'
                                         )
                                         .then(() =>
                                             currentAgent
@@ -657,7 +657,7 @@ describe('Data capture service endpoints', () => {
                                 .post('/apply/applicant-enter-your-name')
                                 .set(
                                     'Cookie',
-                                    'cicaSession=mzBCUTUQGsOT36H6Bvvy5w.D-Om63et1DE6qXBbDvSbsG9A-nw_jL29edAzRc74M7ELpS5am1meqsbNXr5eNhVjQip3H0dRWS9gyIua1h6SVxVPd8X-4BcV4K4RXwnzhEc.1565175346779.900000.4UB0eoITG2We5EDID3nrODqlVqqSzuV72tiJXuzreDg;'
+                                    'session=mzBCUTUQGsOT36H6Bvvy5w.D-Om63et1DE6qXBbDvSbsG9A-nw_jL29edAzRc74M7ELpS5am1meqsbNXr5eNhVjQip3H0dRWS9gyIua1h6SVxVPd8X-4BcV4K4RXwnzhEc.1565175346779.900000.4UB0eoITG2We5EDID3nrODqlVqqSzuV72tiJXuzreDg;'
                                 )
                                 .send()
                                 .then(response => {
@@ -698,7 +698,7 @@ describe('Data capture service endpoints', () => {
                                 .post('/apply/applicant-declaration')
                                 .set(
                                     'Cookie',
-                                    'cicaSession=te3AFsfQozY49T4FIL8lEA.K2YvZ_eUm0YcCg2IA_qtCorcS2T17Td11LC0WmYuTaWc5PQuHcoCTHPuOPQoWVy_R5tUX4vzV4_pENOBxk1xPg0obdlP4suxaGK2YdqxjAE.1565864591496.900000.NwyQHlNP62CAiD-sk2GuuJvLzAQEZjX364hfnLp06yA;'
+                                    'session=te3AFsfQozY49T4FIL8lEA.K2YvZ_eUm0YcCg2IA_qtCorcS2T17Td11LC0WmYuTaWc5PQuHcoCTHPuOPQoWVy_R5tUX4vzV4_pENOBxk1xPg0obdlP4suxaGK2YdqxjAE.1565864591496.900000.NwyQHlNP62CAiD-sk2GuuJvLzAQEZjX364hfnLp06yA;'
                                 )
                                 .then(response => {
                                     expect(response.statusCode).toBe(302);
@@ -742,7 +742,7 @@ describe('Data capture service endpoints', () => {
                                 .post('/apply/applicant-declaration')
                                 .set(
                                     'Cookie',
-                                    'cicaSession=te3AFsfQozY49T4FIL8lEA.K2YvZ_eUm0YcCg2IA_qtCorcS2T17Td11LC0WmYuTaWc5PQuHcoCTHPuOPQoWVy_R5tUX4vzV4_pENOBxk1xPg0obdlP4suxaGK2YdqxjAE.1565864591496.900000.NwyQHlNP62CAiD-sk2GuuJvLzAQEZjX364hfnLp06yA;'
+                                    'session=te3AFsfQozY49T4FIL8lEA.K2YvZ_eUm0YcCg2IA_qtCorcS2T17Td11LC0WmYuTaWc5PQuHcoCTHPuOPQoWVy_R5tUX4vzV4_pENOBxk1xPg0obdlP4suxaGK2YdqxjAE.1565864591496.900000.NwyQHlNP62CAiD-sk2GuuJvLzAQEZjX364hfnLp06yA;'
                                 )
                                 .then(response => {
                                     expect(response.statusCode).toBe(500);
@@ -793,7 +793,7 @@ describe('Data capture service endpoints', () => {
                                     .get('/apply/previous/applicant-enter-your-name')
                                     .set(
                                         'Cookie',
-                                        'cicaSession=mzBCUTUQGsOT36H6Bvvy5w.D-Om63et1DE6qXBbDvSbsG9A-nw_jL29edAzRc74M7ELpS5am1meqsbNXr5eNhVjQip3H0dRWS9gyIua1h6SVxVPd8X-4BcV4K4RXwnzhEc.1565175346779.900000.4UB0eoITG2We5EDID3nrODqlVqqSzuV72tiJXuzreDg;'
+                                        'session=mzBCUTUQGsOT36H6Bvvy5w.D-Om63et1DE6qXBbDvSbsG9A-nw_jL29edAzRc74M7ELpS5am1meqsbNXr5eNhVjQip3H0dRWS9gyIua1h6SVxVPd8X-4BcV4K4RXwnzhEc.1565175346779.900000.4UB0eoITG2We5EDID3nrODqlVqqSzuV72tiJXuzreDg;'
                                     )
                                     .then(response => {
                                         expect(response.statusCode).toBe(302);
@@ -807,7 +807,7 @@ describe('Data capture service endpoints', () => {
                                     .get('/apply/previous/applicant-enter-your-name')
                                     .set(
                                         'Cookie',
-                                        'cicaSession=mzBCUTUQGsOT36H6Bvvy5w.D-Om63et1DE6qXBbDvSbsG9A-nw_jL29edAzRc74M7ELpS5am1meqsbNXr5eNhVjQip3H0dRWS9gyIua1h6SVxVPd8X-4BcV4K4RXwnzhEc.1565175346779.900000.4UB0eoITG2We5EDID3nrODqlVqqSzuV72tiJXuzreDg;'
+                                        'session=mzBCUTUQGsOT36H6Bvvy5w.D-Om63et1DE6qXBbDvSbsG9A-nw_jL29edAzRc74M7ELpS5am1meqsbNXr5eNhVjQip3H0dRWS9gyIua1h6SVxVPd8X-4BcV4K4RXwnzhEc.1565175346779.900000.4UB0eoITG2We5EDID3nrODqlVqqSzuV72tiJXuzreDg;'
                                     )
                                     .then(() =>
                                         // get the csrf token...
@@ -815,7 +815,7 @@ describe('Data capture service endpoints', () => {
                                             .get('/apply/applicant-enter-your-name')
                                             .set(
                                                 'Cookie',
-                                                'cicaSession=mzBCUTUQGsOT36H6Bvvy5w.D-Om63et1DE6qXBbDvSbsG9A-nw_jL29edAzRc74M7ELpS5am1meqsbNXr5eNhVjQip3H0dRWS9gyIua1h6SVxVPd8X-4BcV4K4RXwnzhEc.1565175346779.900000.4UB0eoITG2We5EDID3nrODqlVqqSzuV72tiJXuzreDg;'
+                                                'session=mzBCUTUQGsOT36H6Bvvy5w.D-Om63et1DE6qXBbDvSbsG9A-nw_jL29edAzRc74M7ELpS5am1meqsbNXr5eNhVjQip3H0dRWS9gyIua1h6SVxVPd8X-4BcV4K4RXwnzhEc.1565175346779.900000.4UB0eoITG2We5EDID3nrODqlVqqSzuV72tiJXuzreDg;'
                                             )
                                             .then(() =>
                                                 currentAgent
@@ -860,7 +860,7 @@ describe('Data capture service endpoints', () => {
                                     .get('/apply/previous/applicant-enter-your-name')
                                     .set(
                                         'Cookie',
-                                        'cicaSession=mzBCUTUQGsOT36H6Bvvy5w.D-Om63et1DE6qXBbDvSbsG9A-nw_jL29edAzRc74M7ELpS5am1meqsbNXr5eNhVjQip3H0dRWS9gyIua1h6SVxVPd8X-4BcV4K4RXwnzhEc.1565175346779.900000.4UB0eoITG2We5EDID3nrODqlVqqSzuV72tiJXuzreDg;'
+                                        'session=mzBCUTUQGsOT36H6Bvvy5w.D-Om63et1DE6qXBbDvSbsG9A-nw_jL29edAzRc74M7ELpS5am1meqsbNXr5eNhVjQip3H0dRWS9gyIua1h6SVxVPd8X-4BcV4K4RXwnzhEc.1565175346779.900000.4UB0eoITG2We5EDID3nrODqlVqqSzuV72tiJXuzreDg;'
                                     )
                                     .then(response => {
                                         expect(response.statusCode).toBe(302);
@@ -874,7 +874,7 @@ describe('Data capture service endpoints', () => {
                                     .get('/apply/previous/applicant-enter-your-name')
                                     .set(
                                         'Cookie',
-                                        'cicaSession=mzBCUTUQGsOT36H6Bvvy5w.D-Om63et1DE6qXBbDvSbsG9A-nw_jL29edAzRc74M7ELpS5am1meqsbNXr5eNhVjQip3H0dRWS9gyIua1h6SVxVPd8X-4BcV4K4RXwnzhEc.1565175346779.900000.4UB0eoITG2We5EDID3nrODqlVqqSzuV72tiJXuzreDg;'
+                                        'session=mzBCUTUQGsOT36H6Bvvy5w.D-Om63et1DE6qXBbDvSbsG9A-nw_jL29edAzRc74M7ELpS5am1meqsbNXr5eNhVjQip3H0dRWS9gyIua1h6SVxVPd8X-4BcV4K4RXwnzhEc.1565175346779.900000.4UB0eoITG2We5EDID3nrODqlVqqSzuV72tiJXuzreDg;'
                                     )
                                     .then(response => {
                                         expect(response.res.text).toBe(
@@ -913,7 +913,7 @@ describe('Data capture service endpoints', () => {
                                 .get('/apply/previous/applicant-enter-your-name')
                                 .set(
                                     'Cookie',
-                                    'cicaSession=mzBCUTUQGsOT36H6Bvvy5w.D-Om63et1DE6qXBbDvSbsG9A-nw_jL29edAzRc74M7ELpS5am1meqsbNXr5eNhVjQip3H0dRWS9gyIua1h6SVxVPd8X-4BcV4K4RXwnzhEc.1565175346779.900000.4UB0eoITG2We5EDID3nrODqlVqqSzuV72tiJXuzreDg;'
+                                    'session=mzBCUTUQGsOT36H6Bvvy5w.D-Om63et1DE6qXBbDvSbsG9A-nw_jL29edAzRc74M7ELpS5am1meqsbNXr5eNhVjQip3H0dRWS9gyIua1h6SVxVPd8X-4BcV4K4RXwnzhEc.1565175346779.900000.4UB0eoITG2We5EDID3nrODqlVqqSzuV72tiJXuzreDg;'
                                 )
                                 .then(response => {
                                     expect(response.statusCode).toBe(404);
@@ -944,7 +944,7 @@ describe('Data capture service endpoints', () => {
                                 .get('/apply/previous/applicant-enter-your-name')
                                 .set(
                                     'Cookie',
-                                    'cicaSession=mzBCUTUQGsOT36H6Bvvy5w.D-Om63et1DE6qXBbDvSbsG9A-nw_jL29edAzRc74M7ELpS5am1meqsbNXr5eNhVjQip3H0dRWS9gyIua1h6SVxVPd8X-4BcV4K4RXwnzhEc.1565175346779.900000.4UB0eoITG2We5EDID3nrODqlVqqSzuV72tiJXuzreDg;'
+                                    'session=mzBCUTUQGsOT36H6Bvvy5w.D-Om63et1DE6qXBbDvSbsG9A-nw_jL29edAzRc74M7ELpS5am1meqsbNXr5eNhVjQip3H0dRWS9gyIua1h6SVxVPd8X-4BcV4K4RXwnzhEc.1565175346779.900000.4UB0eoITG2We5EDID3nrODqlVqqSzuV72tiJXuzreDg;'
                                 )
                                 .then(response => {
                                     expect(response.statusCode).toBe(404);
@@ -965,7 +965,7 @@ describe('Data capture service endpoints', () => {
 
                 // mock cookie
                 jest.doMock('client-sessions', () => () => (req, res, next) => {
-                    req.cicaSession = {
+                    req.session = {
                         questionnaireId: 'c7f3b592-b7ac-4f2a-ab9c-8af407ade8cd'
                     };
 


### PR DESCRIPTION
* Add route `/session` - gets the current session information.
* Add route `/session/keep-alive` - refeshes the session and returns the session information.
* Replace `client-sessions` with `express-session` module.
* Update catch-all route to have a `404` status code.
* Update tests