### PR TITLE
Add session buffer

### DIFF
--- a/app.js
+++ b/app.js
@@ -16,6 +16,7 @@ const applicationRouter = require('./questionnaire/routes');
 const downloadRouter = require('./download/routes');
 const sessionRouter = require('./session/routes');
 const createCookieService = require('./cookie/cookie-service');
+const addBuffer = require('./session/utils/addBuffer');
 
 const DURATION_LIMIT = 3600000;
 
@@ -164,8 +165,8 @@ app.use(async (req, res, next) => {
             cookieExpiryService.set({
                 alive: sessionResource.alive,
                 created: sessionResource.created,
-                duration: sessionResource.duration,
-                expires: sessionResource.expires
+                duration: addBuffer(sessionResource.duration),
+                expires: addBuffer(sessionResource.expires)
             });
         }
     } catch (err) {

--- a/session/routes.js
+++ b/session/routes.js
@@ -3,6 +3,7 @@
 const express = require('express');
 const qService = require('../questionnaire/questionnaire-service')();
 const createCookieService = require('../cookie/cookie-service');
+const addBuffer = require('./utils/addBuffer');
 
 const router = express.Router();
 
@@ -16,7 +17,7 @@ router.route('/keep-alive').get(async (req, res) => {
                 res,
                 cookieName: 'sessionExpiry'
             });
-            cookieService.set('expires', sessionResource.expires);
+            cookieService.set('expires', addBuffer(sessionResource.expires));
         }
         res.json(response.body);
     } catch (err) {

--- a/session/utils/addBuffer/addBuffer.test.js
+++ b/session/utils/addBuffer/addBuffer.test.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const addBuffer = require('.');
+
+const INITIAL_DURATION = 120000; // 2 minutes.
+const EXPECTED_BUFFER_VALUE = 30000; // 30 seconds.
+const CUSTOM_BUFFER_VALUE = 12345;
+
+describe('addBuffer', () => {
+    it('Should subtract the default amount from the passed-in value', () => {
+        const result = addBuffer(INITIAL_DURATION);
+        expect(result).toBe(INITIAL_DURATION - EXPECTED_BUFFER_VALUE);
+    });
+
+    it('Should subtract a given amount from the passed-in value', () => {
+        const result = addBuffer(INITIAL_DURATION, CUSTOM_BUFFER_VALUE);
+        expect(result).toBe(INITIAL_DURATION - CUSTOM_BUFFER_VALUE);
+    });
+});

--- a/session/utils/addBuffer/index.js
+++ b/session/utils/addBuffer/index.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const SESSION_DURATION_BUFFER = 30000;
+
+function addBuffer(duration, buffer = SESSION_DURATION_BUFFER) {
+    return duration - buffer;
+}
+
+module.exports = addBuffer;


### PR DESCRIPTION
**I have only tested this on my local machine!!!! not prod-ready**

Once a session has timed out, 1 of 2 things can happen:
* A user does not immediately click the "start again" button on the "timed out" modal - e.g. they left the machine and came back several minutes after the session had already ended.
* A user does immediately click the "start again" button on the "timed out" modal.


This fix will add a negative "buffer" to the session duration so that when the session times out, latency is not a factor in session length interrogation.