### PR TITLE
Add configurable sign-in link

### DIFF
--- a/questionnaire/form-helper.js
+++ b/questionnaire/form-helper.js
@@ -5,6 +5,8 @@ const qTransformer = require('q-transformer')();
 const uiSchema = require('./questionnaireUISchema');
 const sectionList = require('./non-complex-sexual-assault-id-mapper');
 
+const shouldShowSignInLink = require('./utils/shouldShowSignInLink');
+
 nunjucks.configure(
     [
         'node_modules/@ministryofjustice/frontend/',
@@ -44,7 +46,8 @@ function renderSection({
     sectionId,
     showBackLink = true,
     csrfToken,
-    cspNonce
+    cspNonce,
+    showSignInLink = shouldShowSignInLink(sectionId, uiSchema)
 }) {
     const showButton = !isFinal;
     const buttonTitle = getButtonText(sectionId);
@@ -76,6 +79,9 @@ function renderSection({
                     {% endif %}
                     <input type="hidden" name="_csrf" value="${csrfToken}">
                 </form>
+                {% if ${showSignInLink} %}
+                    <a href="/account/sign-in" class="govuk-link">Sign in and continue</a>
+                {% endif %}
             {% endblock %}
         `,
         {nonce: cspNonce}

--- a/questionnaire/questionnaireUISchema.js
+++ b/questionnaire/questionnaireUISchema.js
@@ -1,6 +1,176 @@
 'use strict';
 
 module.exports = {
+    'p--new-or-existing-application': {
+        options: {
+            signInLink: {
+                visible: false
+            }
+        }
+    },
+    'p--contact-cica': {
+        options: {
+            signInLink: {
+                visible: false
+            }
+        }
+    },
+    'p-applicant-fatal-claim': {
+        options: {
+            signInLink: {
+                visible: false
+            }
+        }
+    },
+    'p--was-the-crime-reported-to-police': {
+        options: {
+            outputOrder: ['q--was-the-crime-reported-to-police', 'dont-know-if-crime-reported'],
+            signInLink: {
+                visible: false
+            }
+        }
+    },
+    'p-applicant-you-cannot-get-compensation': {
+        options: {
+            buttonText: 'Continue anyway',
+            signInLink: {
+                visible: false
+            }
+        }
+    },
+    'p-applicant-has-crime-reference-number': {
+        options: {
+            outputOrder: ['q-applicant-has-crime-reference-number', 'crn-info'],
+            signInLink: {
+                visible: false
+            }
+        }
+    },
+    'p-applicant-who-are-you-applying-for': {
+        options: {
+            signInLink: {
+                visible: false
+            }
+        }
+    },
+    'p-applicant-are-you-18-or-over': {
+        options: {
+            signInLink: {
+                visible: false
+            }
+        }
+    },
+    'p--transition': {
+        options: {
+            signInLink: {
+                visible: false
+            }
+        }
+    },
+    'p-applicant-british-citizen-or-eu-national': {
+        options: {
+            signInLink: {
+                visible: false
+            }
+        }
+    },
+    'p--context-applicant-details': {
+        options: {
+            signInLink: {
+                visible: false
+            }
+        }
+    },
+    'p-applicant-confirmation-method': {
+        options: {
+            transformOrder: [
+                'q-applicant-enter-your-email-address',
+                'q-applicant-enter-your-telephone-number',
+                'q-applicant-confirmation-method'
+            ],
+            outputOrder: ['q-applicant-confirmation-method'],
+            properties: {
+                'q-applicant-confirmation-method': {
+                    options: {
+                        conditionalComponentMap: [
+                            {
+                                itemValue: 'email',
+                                componentIds: ['q-applicant-enter-your-email-address']
+                            },
+                            {
+                                itemValue: 'text',
+                                componentIds: ['q-applicant-enter-your-telephone-number']
+                            }
+                        ],
+                        additionalMapping: [
+                            {
+                                itemType: 'divider',
+                                itemValue: 'or',
+                                itemIndex: 2
+                            }
+                        ]
+                    }
+                },
+                'q-applicant-enter-your-email-address': {
+                    options: {
+                        macroOptions: {
+                            classes: 'govuk-input--width-20',
+                            autocomplete: 'email'
+                        }
+                    }
+                },
+                'q-applicant-enter-your-telephone-number': {
+                    options: {
+                        macroOptions: {
+                            classes: 'govuk-input--width-20',
+                            autocomplete: 'tel'
+                        }
+                    }
+                }
+            },
+            signInLink: {
+                visible: false
+            }
+        }
+    },
+    'p--transition-no-phone-or-email': {
+        options: {
+            signInLink: {
+                visible: false
+            }
+        }
+    },
+    'p-applicant-enter-your-name': {
+        options: {
+            signInLink: {
+                visible: false
+            },
+            outputOrder: ['q-applicant-title', 'q-applicant-first-name', 'q-applicant-last-name'],
+            properties: {
+                'q-applicant-title': {
+                    options: {
+                        macroOptions: {
+                            autocomplete: 'honorific-prefix'
+                        }
+                    }
+                },
+                'q-applicant-first-name': {
+                    options: {
+                        macroOptions: {
+                            autocomplete: 'given-name'
+                        }
+                    }
+                },
+                'q-applicant-last-name': {
+                    options: {
+                        macroOptions: {
+                            autocomplete: 'family-name'
+                        }
+                    }
+                }
+            }
+        }
+    },
     'p-applicant-have-you-applied-to-us-before': {
         // transformer: 'form',
         options: {
@@ -127,39 +297,6 @@ module.exports = {
             ]
         }
     },
-    'p--was-the-crime-reported-to-police': {
-        options: {
-            outputOrder: ['q--was-the-crime-reported-to-police', 'dont-know-if-crime-reported']
-        }
-    },
-    'p-applicant-enter-your-name': {
-        options: {
-            outputOrder: ['q-applicant-title', 'q-applicant-first-name', 'q-applicant-last-name'],
-            properties: {
-                'q-applicant-title': {
-                    options: {
-                        macroOptions: {
-                            autocomplete: 'honorific-prefix'
-                        }
-                    }
-                },
-                'q-applicant-first-name': {
-                    options: {
-                        macroOptions: {
-                            autocomplete: 'given-name'
-                        }
-                    }
-                },
-                'q-applicant-last-name': {
-                    options: {
-                        macroOptions: {
-                            autocomplete: 'family-name'
-                        }
-                    }
-                }
-            }
-        }
-    },
     'p-applicant-select-reasons-for-the-delay-in-making-your-application': {
         options: {
             outputOrder: [
@@ -232,11 +369,6 @@ module.exports = {
             showBackButton: false
         }
     },
-    'p-applicant-you-cannot-get-compensation': {
-        options: {
-            buttonText: 'Continue anyway'
-        }
-    },
     'p--which-police-force-is-investigating-the-crime': {
         options: {
             properties: {
@@ -272,55 +404,6 @@ module.exports = {
                 'q-applicant-enter-your-telephone-number': {
                     options: {
                         macroOptions: {
-                            autocomplete: 'tel'
-                        }
-                    }
-                }
-            }
-        }
-    },
-    'p-applicant-confirmation-method': {
-        options: {
-            transformOrder: [
-                'q-applicant-enter-your-email-address',
-                'q-applicant-enter-your-telephone-number',
-                'q-applicant-confirmation-method'
-            ],
-            outputOrder: ['q-applicant-confirmation-method'],
-            properties: {
-                'q-applicant-confirmation-method': {
-                    options: {
-                        conditionalComponentMap: [
-                            {
-                                itemValue: 'email',
-                                componentIds: ['q-applicant-enter-your-email-address']
-                            },
-                            {
-                                itemValue: 'text',
-                                componentIds: ['q-applicant-enter-your-telephone-number']
-                            }
-                        ],
-                        additionalMapping: [
-                            {
-                                itemType: 'divider',
-                                itemValue: 'or',
-                                itemIndex: 2
-                            }
-                        ]
-                    }
-                },
-                'q-applicant-enter-your-email-address': {
-                    options: {
-                        macroOptions: {
-                            classes: 'govuk-input--width-20',
-                            autocomplete: 'email'
-                        }
-                    }
-                },
-                'q-applicant-enter-your-telephone-number': {
-                    options: {
-                        macroOptions: {
-                            classes: 'govuk-input--width-20',
                             autocomplete: 'tel'
                         }
                     }
@@ -1243,11 +1326,6 @@ module.exports = {
     'p-offender-enter-offenders-name': {
         options: {
             outputOrder: ['q-offender-enter-offenders-name', 'additional-info-help-text']
-        }
-    },
-    'p-applicant-has-crime-reference-number': {
-        options: {
-            outputOrder: ['q-applicant-has-crime-reference-number', 'crn-info']
         }
     },
     'p-mainapplicant-confirmation-method': {

--- a/questionnaire/utils/shouldShowSignInLink/index.js
+++ b/questionnaire/utils/shouldShowSignInLink/index.js
@@ -1,0 +1,12 @@
+'use strict';
+
+function shouldShowSignInLink(sectionId, uiSchema) {
+    const defaultVisibility = true;
+    const isVisible = uiSchema[sectionId]?.options?.signInLink?.visible;
+    if (isVisible !== undefined) {
+        return isVisible;
+    }
+    return defaultVisibility;
+}
+
+module.exports = shouldShowSignInLink;

--- a/questionnaire/utils/shouldShowSignInLink/shouldShowSignInLink.test.js
+++ b/questionnaire/utils/shouldShowSignInLink/shouldShowSignInLink.test.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const shouldShowSignInLink = require('.');
+
+const uiSchema = {
+    section1: {
+        options: {
+            foo: 'bar'
+        }
+    },
+    section2: {
+        options: {
+            signInLink: {
+                visible: false
+            }
+        }
+    },
+    section3: {
+        options: {
+            signInLink: {
+                visible: true
+            }
+        }
+    }
+};
+
+describe('shouldShowSignInLink', () => {
+    it('Should return true by default', () => {
+        const result = shouldShowSignInLink('section1', uiSchema);
+        expect(result).toBe(true);
+    });
+    it('Should return false', () => {
+        const result = shouldShowSignInLink('section2', uiSchema);
+        expect(result).toBe(false);
+    });
+    it('Should return true', () => {
+        const result = shouldShowSignInLink('section3', uiSchema);
+        expect(result).toBe(true);
+    });
+});

--- a/test/form-helper.test.js
+++ b/test/form-helper.test.js
@@ -4,6 +4,9 @@ const formHelper = require('../questionnaire/form-helper');
 const validTransformation = require('./test-fixtures/transformations/p-applicant-british-citizen-or-eu-national');
 const validResolvedHtml = require('./test-fixtures/transformations/resolved html/p-applicant-british-citizen-or-eu-national');
 
+const shouldShowSignInLink = require('../questionnaire/utils/shouldShowSignInLink');
+const uiSchema = require('../questionnaire/questionnaireUISchema');
+
 describe('form-helper functions', () => {
     describe('Remove sectionId prefix', () => {
         it('Should remove p- or p-- from the beginning of a valid sectionId', () => {
@@ -154,6 +157,66 @@ describe('form-helper functions', () => {
                 .replace(/\s+/g, '');
 
             expect(actual).toMatch(expected);
+        });
+
+        it('Should show sign-in link when explicitly specified', () => {
+            const transformation = validTransformation;
+            const isFinal = false;
+            const backTarget = '/apply/previous/applicant-when-did-the-crime-stop';
+            const sectionId = 'p-applicant-when-did-the-crime-stop';
+            const showBackLink = true;
+            const csrfToken = 'sometoken';
+            const cspNonce = 'somenonce';
+            const showSignInLink = shouldShowSignInLink(sectionId, uiSchema);
+            const expected = '<a href="/account/sign-in" class="govuk-link">Sign in and continue</a>'.replace(
+                /\s+/g,
+                ''
+            );
+
+            const result = formHelper
+                .renderSection({
+                    transformation,
+                    isFinal,
+                    backTarget,
+                    sectionId,
+                    showBackLink,
+                    csrfToken,
+                    cspNonce,
+                    showSignInLink
+                })
+                .replace(/\s+/g, '');
+
+            expect(result).toEqual(expect.stringContaining(expected));
+        });
+
+        it('Should not show sign-in link when explicitly specified', () => {
+            const transformation = validTransformation;
+            const isFinal = false;
+            const backTarget = '/apply/previous/applicant-who-are-you-applying-for';
+            const sectionId = 'p-applicant-who-are-you-applying-for';
+            const showBackLink = true;
+            const csrfToken = 'sometoken';
+            const cspNonce = 'somenonce';
+            const showSignInLink = shouldShowSignInLink(sectionId, uiSchema);
+            const expected = '<a href="/account/sign-in" class="govuk-link">Sign in and continue</a>'.replace(
+                /\s+/g,
+                ''
+            );
+
+            const result = formHelper
+                .renderSection({
+                    transformation,
+                    isFinal,
+                    backTarget,
+                    sectionId,
+                    showBackLink,
+                    csrfToken,
+                    cspNonce,
+                    showSignInLink
+                })
+                .replace(/\s+/g, '');
+
+            expect(result).toEqual(expect.not.stringContaining(expected));
         });
     });
 


### PR DESCRIPTION
add a configuration option to the `UISchema` to show or hide the "sign in" link per page.
*NOTE*: nothing has been deleted from the `UISchema`, only moved or added to.

Regarding [this](https://github.com/CriminalInjuriesCompensationAuthority/cica-web/blob/ba3ff0edb2bd5100671ed11ca652d71c24cc7ab4/questionnaire/form-helper.js#L50): The default parameter function parameters includes `sectionId` This is the same `sectionId` that is defined previously in the same function formal parameters. As long as they are defined in this order (in the function signature. Order is irrelevant on function call), there will not be a reference error thrown.

Simplified example below.

````
// variable `a` is defined, only, in the function signature. It is not in the parent scope.
const c = 3;
function add(operand1, operand2) {
    return operand1 + operand2;
}
function test({a, b = add(a, c)}) {
    console.log(a, b, c);
}
test({a: 1}); // 1, 4, 3



// variable `a` is defined after the other parameter that references variable `a`.
const c = 3;
function add(operand1, operand2) {
    return operand1 + operand2;
}
function test({b = add(a, c), a}) {
    console.log(a, b, c);
}
test({a: 1}); // Uncaught ReferenceError: Cannot access 'a' before initialization
````