### PR TITLE
Improve Date() usage for easier testing

### DIFF
--- a/index/liveChatHelper.js
+++ b/index/liveChatHelper.js
@@ -30,7 +30,7 @@ function createLiveChatHelper() {
     }
 
     function isBankHoliday() {
-        return bankHolidays.events.some(x => moment(x.date).isSame(new Date(), 'day'));
+        return bankHolidays.events.some(x => moment(x.date).isSame(new Date(Date.now()), 'day'));
     }
 
     function isLiveChatActive(startTimes, endTimes) {
@@ -39,7 +39,7 @@ function createLiveChatHelper() {
         }
         const startTimesArray = getOperationalTimesOfDayFromString(startTimes);
         const endTimesArray = getOperationalTimesOfDayFromString(endTimes);
-        const today = new Date();
+        const today = new Date(Date.now());
         const dayOfWeek = today.getDay(); // Sunday = 0, Saturday = 6.
 
         if (startTimesArray[dayOfWeek] !== 'false') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "cica-web",
-    "version": "5.2.3",
+    "version": "5.2.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "cica-web",
-            "version": "5.2.3",
+            "version": "5.2.4",
             "license": "MIT",
             "dependencies": {
                 "@ministryofjustice/frontend": "0.0.17-alpha",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cica-web",
-    "version": "5.2.3",
+    "version": "5.2.4",
     "engines": {
         "npm": ">=8.5.2",
         "node": ">=16.0.0"

--- a/test/live-chat.test.js
+++ b/test/live-chat.test.js
@@ -14,10 +14,12 @@ describe('Live Chat', () => {
 
     beforeEach(() => {
         jest.resetModules();
+        jest.spyOn(Date, 'now').mockImplementation(() => 1631538356000);
         process.env = {...OLD_ENV};
     });
 
     afterEach(() => {
+        jest.clearAllMocks();
         process.env = OLD_ENV;
     });
 
@@ -82,7 +84,7 @@ describe('Live Chat', () => {
         });
 
         describe('Maintenance message content', () => {
-            it('Should display default maintenance banner content if env var is nor present', async () => {
+            it('Should display default maintenance banner content if env var is not present', async () => {
                 process.env.CW_LIVECHAT_MAINTENANCE_MESSAGE_ENABLED = 'true';
                 delete process.env.CW_LIVECHAT_MAINTENANCE_MESSAGE;
                 startApp();


### PR DESCRIPTION
Mocking Date.now() enables the creation of any date needed in a test. Avoiding the need to mock both Date(), and Date.now()

Tests were failing today due to today being a Scottish bank holiday. An oversight on an unrelated test.

Mocked response from Date.now.

proposed version bump: `v5.2.4` (patch)