### PR TITLE
Replace deprecated aws get-login method with get-login-password

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,7 @@ jobs:
           name: Authenticate and push image to ecr
           command: |
             echo "run aws"
-            $(aws ecr get-login --region eu-west-2 --no-include-email)
+            aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin 754256621582.dkr.ecr.eu-west-2.amazonaws.com
             docker tag cica/cica-repo-dev:latest ${ECR_REPOSITORY}/cica/cica-repo-dev:${CIRCLE_SHA1}
             docker push ${ECR_REPOSITORY}/cica/cica-repo-dev:${CIRCLE_SHA1}
             if [ "${CIRCLE_BRANCH}" ==  "cw-deploy" ]; then

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "cica-web",
-    "version": "5.2.6",
+    "version": "5.2.7",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "cica-web",
-            "version": "5.2.6",
+            "version": "5.2.7",
             "license": "MIT",
             "dependencies": {
                 "@ministryofjustice/frontend": "0.0.17-alpha",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cica-web",
-    "version": "5.2.6",
+    "version": "5.2.7",
     "engines": {
         "npm": ">=8.5.2",
         "node": ">=16.0.0"


### PR DESCRIPTION
- replaced deprecated aws client get-login method with get-login-password see [login to the repository](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/helloworld-app-deploy.html#login-to-the-repository)