### PR TITLE
Character count with free text boxes

### DIFF
--- a/questionnaire/form-helper.js
+++ b/questionnaire/form-helper.js
@@ -162,6 +162,17 @@ function addPrefix(section) {
     return sectionList[section];
 }
 
+function removeCarriageReturns(body, property) {
+    const answers = body;
+    const value = answers[property];
+
+    // Remove carriage returns as these increase the character count causing validation error and are added by the http tranmission. They are not part of the original answer from frontend
+    if (typeof value === 'string') {
+        answers[property] = answers[property].replace(/\r\n/g, '\n');
+    }
+    return answers;
+}
+
 function processRequest(rawBody, section) {
     // Handle conditionally revealing routes
     let body = rawBody;
@@ -173,6 +184,7 @@ function processRequest(rawBody, section) {
         Object.keys(body).forEach(question => {
             body = removeEmptyAnswers(body, question);
             body = correctPartialDates(body, question);
+            body = removeCarriageReturns(body, question);
         });
         return body;
     }
@@ -282,5 +294,6 @@ module.exports = {
     getSectionHtmlWithErrors,
     addPrefix,
     escapeSchemaContent,
-    getSectionContext
+    getSectionContext,
+    removeCarriageReturns
 };

--- a/test/form-helper.test.js
+++ b/test/form-helper.test.js
@@ -538,13 +538,13 @@ describe('form-helper functions', () => {
         });
     });
 
-    describe('Remove "carriage returns" answer string', () => {
-        it('Should return a valid sectionId given a section name exists in the questionnaire', () => {
+    describe('Remove "carriage returns" from answer string', () => {
+        it('Should return an answer with carriage returns removed', () => {
             let body = {
-                Q1: 'foo\r\nbar'
+                Q1: 'foo\r\nbar\r\nfoo\r\nbar\r\nfoo\r\nbar foo bar.'
             };
             const expected = {
-                Q1: 'foo\nbar'
+                Q1: 'foo\nbar\nfoo\nbar\nfoo\nbar foo bar.'
             };
 
             Object.keys(body).forEach(property => {

--- a/test/form-helper.test.js
+++ b/test/form-helper.test.js
@@ -537,4 +537,21 @@ describe('form-helper functions', () => {
             expect(formHelper.escapeSchemaContent(schema)).toEqual(expected);
         });
     });
+
+    describe('Remove "carriage returns" answer string', () => {
+        it('Should return a valid sectionId given a section name exists in the questionnaire', () => {
+            let body = {
+                Q1: 'foo\r\nbar'
+            };
+            const expected = {
+                Q1: 'foo\nbar'
+            };
+
+            Object.keys(body).forEach(property => {
+                body = formHelper.removeCarriageReturns(body, property);
+            });
+
+            expect(body).toMatchObject(expected);
+        });
+    });
 });


### PR DESCRIPTION
When a user is entering free text into any free text page of the application form and presses space for a new line it deducts the character count as required however depending on the number of lines the user takes to start a new paragraph when it reaches 2000 characters it tells the user they’ve used more than 2000 characters. (Briefly describe the crime and additional information boxes as examples) If the user takes 3 spaces and then enters 1997 characters instead of 2000 they are told they’ve used more than 2000 characters which is incorrect. If the user then enters 1996 characters they are able to proceed. Stephen Sinclair thinks this could be down to possibly a difference in code being developed on a mac but testing done with windows.

CoS

User can enter max characters in any freetext box, including line spacing, and continue without an error message

Q-IDs

q-applicant-incident-description

q-applicant-affect-on-daily-life-dmi

q-applicant-additional-information