### PR TITLE
Remove redundant sorting from `action` column

### DIFF
--- a/account/partials/dashboard.njk
+++ b/account/partials/dashboard.njk
@@ -33,10 +33,7 @@
                }
             },
             {
-              text: "Action",
-              attributes: {
-                "aria-sort": "none"
-              }
+              text: "Action"
             }
           ],
           rows: userData


### PR DESCRIPTION
Remove the ability to sort the `action` column at this time. It will only have 1 possible value, so sorting is redundant.