### PR TITLE
Add `/apply/new` route

### DIFF
--- a/account/partials/dashboard.njk
+++ b/account/partials/dashboard.njk
@@ -11,7 +11,7 @@
     {{ govukButton({
         text: "Start a new application",
         classes: "govuk-button--secondary",
-        href: "/apply"
+        href: "/apply/new"
     }) }}
 
     <div class="moj-scrollable-pane">

--- a/questionnaire/questionnaire-service.js
+++ b/questionnaire/questionnaire-service.js
@@ -29,7 +29,7 @@ function questionnaireService() {
         return service.post(opts);
     }
 
-    async function createQuestionnaire(init) {
+    async function createQuestionnaire(options) {
         const opts = {
             url: `${process.env.CW_DCS_URL}/api/v1/questionnaires`,
             headers: {
@@ -44,10 +44,10 @@ function questionnaireService() {
                 }
             }
         };
-        const response = service.post(opts);
+        const response = await service.post(opts);
 
-        if (init?.userId) {
-            const data = {'user-id': init.userId};
+        if (options?.userId) {
+            const data = {'user-id': options.userId};
             await postSection(response.body.data.attributes.id, 'user', data);
         }
 

--- a/questionnaire/routes.js
+++ b/questionnaire/routes.js
@@ -19,6 +19,15 @@ router.route('/').get(async (req, res) => {
     }
 });
 
+router.route('/new').get(async (req, res) => {
+    try {
+        req.session.questionnaireId = undefined;
+        res.redirect('/apply');
+    } catch (err) {
+        res.status(err.statusCode || 404).render('404.njk');
+    }
+});
+
 router.route('/resume/:questionnaireId').get(async (req, res) => {
     try {
         const defaultRedirect = '/apply';

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -876,6 +876,15 @@ describe('/apply', () => {
             );
         });
     });
+
+    describe('/new', () => {
+        it('Should redirect to `/apply`', async () => {
+            const currentAgent = request.agent(app);
+            await currentAgent.get('/apply');
+            const response = await currentAgent.get('/apply/new');
+            expect(response.text).toBe('Found. Redirecting to /apply');
+        });
+    });
 });
 
 describe('/session', () => {


### PR DESCRIPTION
clears `questionnaireId` from session and redirects the user back to `/apply`.

* Added new `/apply/new` route
* Fixed bug in `questionnaire-service.js` where a promise was not being `await`ed
* tests