### PR TITLE
Remove instance id from session on completion

### DIFF
--- a/questionnaire/routes.js
+++ b/questionnaire/routes.js
@@ -183,7 +183,7 @@ router
                 isAuthenticated
             );
             if (formHelper.getSectionContext(sectionId) === 'confirmation') {
-                res.clearCookie('session');
+                delete req.session.questionnaireId;
             }
             res.send(html);
         } catch (err) {


### PR DESCRIPTION
Only alter the session upon questionnaire submission, do not destroy it. This way the user will still be logged in after a submission.