### PR TITLE
Bp feature/save and return/dcs integration

### DIFF
--- a/account/account-service.js
+++ b/account/account-service.js
@@ -9,17 +9,21 @@ function createAccountService(session) {
         return `urn:uuid:${crypto.randomUUID()}`;
     }
 
-    function getOwnerId() {
-        return currentSession?.ownerId;
-    }
-
     function generateOwnerId() {
-        if (getOwnerId()) {
-            return getOwnerId();
-        }
         const ownerId = URN_UUID();
         currentSession.ownerId = ownerId;
         return ownerId;
+    }
+
+    function getOwnerId() {
+        if (!currentSession?.ownerId) {
+            return generateOwnerId();
+        }
+        return currentSession?.ownerId;
+    }
+
+    function setOwnerId(id) {
+        currentSession.ownerId = id;
     }
 
     function isAuthenticated(req) {
@@ -28,7 +32,7 @@ function createAccountService(session) {
 
     return Object.freeze({
         getOwnerId,
-        generateOwnerId,
+        setOwnerId,
         isAuthenticated
     });
 }

--- a/account/pages/dashboard.njk
+++ b/account/pages/dashboard.njk
@@ -1,6 +1,43 @@
 {% extends "page.njk" %}
+{% from "components/button/macro.njk" import govukButton %}
+{%- from "components/table/macro.njk" import govukTable -%}
+
 {% block pageTitle %}Active Applications - {{ super() }}{% endblock %}
 
 {% block innerContent %}
-    <h1 class="govuk-heading-xl">Dashboard</h1>
+    <h1 class="govuk-heading-xl">Active Applications</h1>
+    <p class="govuk-body govuk-!-font-size-24">An application is <strong>saved for 30 days</strong> from when you start it.</p>
+    <p class="govuk-body">If you do not submit it before this date, it will be deleted and you'll need to start a new application</p>
+    {{ govukButton({
+        text: "Start a new application",
+        classes: "govuk-button--secondary",
+        href: "/apply/start"
+    }) }}
+
+    <div class="moj-scrollable-pane">
+        {{ govukTable({
+          attributes: {
+            'data-module': 'moj-sortable-table'
+          },
+          head: [
+            {
+              text: "Applicant name",
+              attributes: {
+                "aria-sort": "none"
+              }
+            },
+            {
+              text: "Expiry date",
+               attributes: {
+                 "aria-sort": "descending"
+               }
+            },
+            {
+              text: "Action"
+            }
+          ],
+          rows: userData
+        }) }}
+    </div>
+
 {% endblock %}

--- a/account/routes.js
+++ b/account/routes.js
@@ -6,10 +6,12 @@ const createTemplateEngineService = require('../templateEngine');
 const getValidReferrerOrDefault = require('./utils/getValidReferrerOrDefault');
 const {getDashboardURI} = require('./utils/getActionURIs');
 const createAccountService = require('./account-service');
+const createQuestionnaireService = require('../questionnaire/questionnaire-service');
+const getQuestionnaireIdInSession = require('../questionnaire/utils/getQuestionnaireIdInSession');
 
 const router = express.Router();
 
-router.get('/sign-in/success', requiresAuth(), (req, res, next) => {
+router.get('/sign-in/success', requiresAuth(), async (req, res, next) => {
     try {
         const expiryDate = new Date(
             new Date().setDate(new Date().getDate() + 31)
@@ -18,12 +20,25 @@ router.get('/sign-in/success', requiresAuth(), (req, res, next) => {
         const templateEngineService = createTemplateEngineService();
         const accountService = createAccountService(req.session);
         const {render} = templateEngineService;
+
+        const questionnaireId = getQuestionnaireIdInSession(req.session);
+        if (questionnaireId) {
+            const questionnaireService = createQuestionnaireService({
+                id: accountService.getOwnerId(),
+                isAuthenticated: true
+            });
+            await questionnaireService.postSection(questionnaireId, 'owner', {
+                id: req.oidc.user.sub,
+                isAuthenticated: true
+            });
+        }
+        accountService.setOwnerId(req.oidc.user.sub);
+
         const html = render('authentication-success.njk', {
             nextPageUrl: getValidReferrerOrDefault(req?.session?.referrer),
             expiryDate,
             isAuthenticated: accountService.isAuthenticated(req)
         });
-
         return res.send(html);
     } catch (err) {
         res.status(err.statusCode || 404).render('404.njk');

--- a/app.js
+++ b/app.js
@@ -157,7 +157,8 @@ const oidcConfig = {
     afterCallback: async (req, res, session) => {
         return {
             ...session,
-            questionnaireId: req.session.questionnaireId
+            questionnaireId: req.session.questionnaireId,
+            ownerId: req.session.ownerId
         };
     }
 };

--- a/questionnaire/questionnaire-service.js
+++ b/questionnaire/questionnaire-service.js
@@ -31,7 +31,8 @@ function questionnaireService(options = {}) {
             url: `${process.env.CW_DCS_URL}/api/v1/questionnaires/${questionnaireId}/progress-entries?filter[sectionId]=${section}`,
             headers: {
                 Authorization: `Bearer ${process.env.CW_DCS_JWT}`,
-                'On-Behalf-Of': options.ownerId
+                'On-Behalf-Of': options.ownerId,
+                'Dcs-Api-Version': '2023-05-17'
             }
         };
         return service.get(opts);
@@ -42,7 +43,8 @@ function questionnaireService(options = {}) {
             url: `${process.env.CW_DCS_URL}/api/v1/questionnaires/${questionnaireId}/sections/${section}/answers`,
             headers: {
                 Authorization: `Bearer ${process.env.CW_DCS_JWT}`,
-                'On-Behalf-Of': options.ownerId
+                'On-Behalf-Of': options.ownerId,
+                'Dcs-Api-Version': '2023-05-17'
             },
             json: {
                 data: {
@@ -59,7 +61,8 @@ function questionnaireService(options = {}) {
             url: `${process.env.CW_DCS_URL}/api/v1/questionnaires/${questionnaireId}/progress-entries?page[before]=${sectionId}`,
             headers: {
                 Authorization: `Bearer ${process.env.CW_DCS_JWT}`,
-                'On-Behalf-Of': options.ownerId
+                'On-Behalf-Of': options.ownerId,
+                'Dcs-Api-Version': '2023-05-17'
             }
         };
         return service.get(opts);
@@ -70,7 +73,8 @@ function questionnaireService(options = {}) {
             url: `${process.env.CW_DCS_URL}/api/v1/questionnaires/${currentQuestionnaireId}/progress-entries?filter[position]=current`,
             headers: {
                 Authorization: `Bearer ${process.env.CW_DCS_JWT}`,
-                'On-Behalf-Of': options.ownerId
+                'On-Behalf-Of': options.ownerId,
+                'Dcs-Api-Version': '2023-05-17'
             }
         };
         return service.get(opts);
@@ -148,7 +152,8 @@ function questionnaireService(options = {}) {
             url: `${process.env.CW_DCS_URL}/api/v1/questionnaires/${currentQuestionnaireId}/progress-entries?filter[position]=first`,
             headers: {
                 Authorization: `Bearer ${process.env.CW_DCS_JWT}`,
-                'On-Behalf-Of': options.ownerId
+                'On-Behalf-Of': options.ownerId,
+                'Dcs-Api-Version': '2023-05-17'
             }
         };
         return service.get(opts);

--- a/questionnaire/routes.js
+++ b/questionnaire/routes.js
@@ -71,7 +71,6 @@ router.post('/start-or-resume', (req, res) => {
 router.route('/start').get(async (req, res) => {
     try {
         const accountService = createAccountService(req.session);
-        accountService.generateOwnerId();
         const questionnaireService = createQuestionnaireService({
             ownerId: accountService.getOwnerId(),
             isAuthenticated: accountService.isAuthenticated(req)


### PR DESCRIPTION
Adrian's latest branches after rebase.

* Add dcs header to these requests:
    * `/api/v1/questionnaires/${questionnaireId}/sections/${section}/answers`
    * `/api/v1/questionnaires/${questionnaireId}/progress-entries`
* Added posting of owner data in return from OIDC provider (on `/account/sign-in/success`). Given that the `afterCallback` function is documented as used for validating claims, I didn't want to put this arbitrary logic in it.