### PR TITLE
Cache assets within pages

### DIFF
--- a/.huskyrc.js
+++ b/.huskyrc.js
@@ -9,4 +9,3 @@ const config = {
 /*! m0-start */
 module.exports = config;
 /*! m0-end */
-

--- a/app.js
+++ b/app.js
@@ -156,27 +156,39 @@ app.use(
     })
 );
 
-app.use(express.static(path.join(__dirname, 'public')));
+const cacheTime = 365 * 24 * 60 * 60 * 1000; // the unit is milliseconds
+
+app.use(
+    express.static(path.join(__dirname, 'public'), {
+        maxAge: cacheTime // the unit is milliseconds
+    })
+);
 
 app.use(
     '/assets',
-    express.static(path.join(__dirname, '/node_modules/govuk-frontend/govuk/assets'))
+    express.static(path.join(__dirname, '/node_modules/govuk-frontend/govuk/assets'), {
+        maxAge: cacheTime
+    })
 );
 app.use(
     '/govuk-frontend/all.css',
-    express.static(path.join(__dirname, '/public/stylesheets/all.css'))
+    express.static(path.join(__dirname, '/public/stylesheets/all.css'), {maxAge: cacheTime})
 );
 app.use(
     '/govuk-frontend/all-ie8.css',
-    express.static(path.join(__dirname, '/public/stylesheets/all-ie8.css'))
+    express.static(path.join(__dirname, '/public/stylesheets/all-ie8.css'), {maxAge: cacheTime})
 );
 app.use(
     '/govuk-frontend/all.js',
-    express.static(path.join(__dirname, '/node_modules/govuk-frontend/govuk/all.js'))
+    express.static(path.join(__dirname, '/node_modules/govuk-frontend/govuk/all.js'), {
+        maxAge: cacheTime
+    })
 );
 app.use(
     '/moj-frontend/all.js',
-    express.static(path.join(__dirname, '/node_modules/@ministryofjustice/frontend/moj/all.js'))
+    express.static(path.join(__dirname, '/node_modules/@ministryofjustice/frontend/moj/all.js'), {
+        maxAge: cacheTime
+    })
 );
 
 app.use(

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -18,3 +18,4 @@ process.env.CW_GOVUK_CLIENT_ID = 'thisistheclientid';
 process.env.CW_GOVUK_PRIVATE_KEY = 'thisisthegovukprivatekey';
 process.env.CW_GOVUK_ISSUER_URL = 'http://www.80443328-da85-42de-8a3d-06e1d8f8fcc8.gov.uk';
 process.env.CW_SESSION_DURATION = 1800000;
+process.env.npm_package_version = '1.2.3';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "cica-web",
-    "version": "7.1.14",
+    "version": "7.1.15",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "cica-web",
-            "version": "7.1.14",
+            "version": "7.1.15",
             "license": "MIT",
             "dependencies": {
                 "@ministryofjustice/frontend": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cica-web",
-    "version": "7.1.14",
+    "version": "7.1.15",
     "engines": {
         "npm": ">=9.5.0",
         "node": ">=18.16.1"

--- a/page/blank.njk
+++ b/page/blank.njk
@@ -62,6 +62,6 @@
         <script nonce="{{ cspNonce }}" src="/govuk-frontend/all.js"></script>
         <script nonce="{{ cspNonce }}">window.GOVUKFrontend.initAll()</script>
         <script nonce="{{ cspNonce }}" src="/dist/js/autocomplete.min.js"></script>
-        <script nonce="{{ cspNonce }}" src="/dist/js/bundle.js"></script>
+        <script nonce="{{ cspNonce }}" src="/dist/js/bundle.js?{{CW_APP_VERSION}}"></script>
     </body>
 </html>

--- a/page/page.njk
+++ b/page/page.njk
@@ -122,7 +122,7 @@
     <script nonce="{{ cspNonce }}">window.GOVUKFrontend.initAll()</script>
     <script nonce="{{ cspNonce }}" src="https://code.jquery.com/jquery-3.6.3.min.js" integrity="sha256-pvPw+upLPUjgMXY0G+8O0xUf+/Im1MZjXxxgOcBQBXU=" crossorigin="anonymous"></script>
     <script nonce="{{ cspNonce }}" src="/dist/js/autocomplete.min.js"></script>
-    <script nonce="{{ cspNonce }}" src="/dist/js/bundle.js"></script>
+    <script nonce="{{ cspNonce }}" src="/dist/js/bundle.js?{{CW_APP_VERSION}}"></script>
 {% endblock %}
 
 {% block footer %}

--- a/templateEngine/index.js
+++ b/templateEngine/index.js
@@ -56,7 +56,8 @@ function createTemplateEngineService(app) {
             .addGlobal(
                 'CW_MAINTENANCE_MESSAGE_ENABLED',
                 process.env.CW_MAINTENANCE_MESSAGE_ENABLED === 'true'
-            );
+            )
+            .addGlobal('CW_APP_VERSION', process.env.npm_package_version);
 
         return environment;
     }

--- a/test/test-fixtures/transformations/resolved html/p-applicant-british-citizen-or-eu-national.js
+++ b/test/test-fixtures/transformations/resolved html/p-applicant-british-citizen-or-eu-national.js
@@ -546,7 +546,7 @@ window.CICA = {
   <script nonce="somenonce">window.GOVUKFrontend.initAll()</script>
   <script nonce="somenonce" src="https://code.jquery.com/jquery-3.6.3.min.js "integrity="sha256-pvPw+upLPUjgMXY0G+8O0xUf+/Im1MZjXxxgOcBQBXU="crossorigin="anonymous"></script>
   <script nonce="somenonce" src="/dist/js/autocomplete.min.js"></script>
-  <script nonce="somenonce" src="/dist/js/bundle.js"></script>
+  <script nonce="somenonce" src="/dist/js/bundle.js?1.2.3"></script>
   </body>
 </html>
 `;


### PR DESCRIPTION
Assets were not caching correctly in chrome or edge. In order to fix this a maxAge tag has been added to all assets. In order to ensure that any new code deploys that change the bundle correctly override a user's cached version of the bundle, bundle names now include a hash. The template files are updated to include this hash using a new script run when `npm run build` is called.