### PR TITLE
Add nonce to inline and included scripts

### DIFF
--- a/account/routes.js
+++ b/account/routes.js
@@ -50,7 +50,7 @@ router.get('/sign-in/success', requiresAuth(), async (req, res, next) => {
             nextPageUrl: getValidReferrerOrDefault(req?.session?.referrer),
             expiryDate,
             isAuthenticated: accountService.isAuthenticated(req),
-            nonce: res.locals.nonce
+            cspNonce: res.locals.cspNonce
         });
         accountService.setOwnerId(req.oidc.user.sub);
         return res.send(html);
@@ -112,7 +112,7 @@ router.get('/dashboard', requiresAuth(), async (req, res, next) => {
             csrfToken: req.csrfToken(),
             isAuthenticated: accountService.isAuthenticated(req),
             ownerData,
-            nonce: res.locals.nonce
+            cspNonce: res.locals.cspNonce
         });
         return res.send(html);
     } catch (err) {

--- a/app.js
+++ b/app.js
@@ -107,7 +107,7 @@ const oidcAuth = auth({
 });
 
 app.use((req, res, next) => {
-    res.locals.nonce = nanoid();
+    res.locals.cspNonce = nanoid();
     res.set('Application-Version', process.env.npm_package_version);
     next();
 });
@@ -115,14 +115,19 @@ app.use((req, res, next) => {
 app.use(
     helmet({
         contentSecurityPolicy: {
+            useDefaults: true,
+            xXssProtection: false,
             directives: {
+                baseUri: ["'self'"],
                 defaultSrc: ["'self'"],
                 scriptSrc: [
                     "'self'",
-                    (req, res) => `'nonce-${res.locals.nonce}'`,
-                    "'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU='", // hash of the inline script in frontend template.njk.
-                    '*.googletagmanager.com',
-                    "'sha256-pvPw+upLPUjgMXY0G+8O0xUf+/Im1MZjXxxgOcBQBXU='" // hash of the inline script used for jQuery.
+                    "'strict-dynamic'",
+                    // https://content-security-policy.com/unsafe-inline/
+                    // "it is only ok to use unsafe-inline when it is combined with the strict-dynamic csp directive."
+                    "'unsafe-inline'",
+                    (req, res) => `'nonce-${res.locals.cspNonce}'`,
+                    'https:'
                 ],
                 imgSrc: ["'self'", 'data:', '*.google-analytics.com', 'www.googletagmanager.com'],
                 objectSrc: ["'none'"],

--- a/page/blank.njk
+++ b/page/blank.njk
@@ -34,11 +34,11 @@
     </head>
     <body class="govuk-template__body ">
 
-        <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
+        <script nonce="{{ cspNonce }}">document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
     
         <!-- Global site tag (gtag.js) - Google Analytics -->
-        <script async src="https://www.googletagmanager.com/gtag/js?id={{ CW_GA_TRACKING_ID }}"></script>
-        <script nonce="{{ nonce }}">
+        <script nonce="{{ cspNonce }}" async src="https://www.googletagmanager.com/gtag/js?id={{ CW_GA_TRACKING_ID }}"  integrity="sha256-reslnxoE9Ubh0YBekM4KFBNnj9mOmSzsx6lRGE9p7H4=" crossorigin="anonymous"></script>
+        <script nonce="{{ cspNonce }}">
             window.dataLayer = window.dataLayer || [];
             function gtag(){
                 dataLayer.push(arguments);
@@ -53,15 +53,15 @@
         {% endblock %}
 
         {# Run JavaScript at end of the <body>, to avoid blocking the initial render. #}
-        <script nonce="{{ nonce }}">
+        <script nonce="{{ cspNonce }}">
             window.CICA = {
                 SERVICE_URL: '{{ CW_URL }}',
                 ANALYTICS_TRACKING_ID: '{{ CW_GA_TRACKING_ID }}'
             };
         </script>
-        <script src="/govuk-frontend/all.js"></script>
-        <script nonce="{{ nonce }}">window.GOVUKFrontend.initAll()</script>
-        <script src="/dist/js/autocomplete.min.js"></script>
-        <script src="/dist/js/bundle.js"></script>
+        <script nonce="{{ cspNonce }}" src="/govuk-frontend/all.js"></script>
+        <script nonce="{{ cspNonce }}">window.GOVUKFrontend.initAll()</script>
+        <script nonce="{{ cspNonce }}" src="/dist/js/autocomplete.min.js"></script>
+        <script nonce="{{ cspNonce }}" src="/dist/js/bundle.js"></script>
     </body>
 </html>

--- a/page/page.njk
+++ b/page/page.njk
@@ -34,8 +34,8 @@
 
 {% block bodyStart %}
     <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id={{ CW_GA_TRACKING_ID }}"></script>
-    <script nonce="{{ nonce }}">
+    <script nonce="{{ cspNonce }}" async src="https://www.googletagmanager.com/gtag/js?id={{ CW_GA_TRACKING_ID }}" integrity="sha256-reslnxoE9Ubh0YBekM4KFBNnj9mOmSzsx6lRGE9p7H4=" crossorigin="anonymous"></script>
+    <script nonce="{{ cspNonce }}">
         window.dataLayer = window.dataLayer || [];
         function gtag(){
             dataLayer.push(arguments);
@@ -110,17 +110,17 @@
 {% block bodyEnd %}
     {% include "modal-timeout.njk" %}
     {# Run JavaScript at end of the <body>, to avoid blocking the initial render. #}
-    <script nonce="{{ nonce }}">
+    <script nonce="{{ cspNonce }}">
         window.CICA = {
             SERVICE_URL: '{{ CW_URL }}',
             ANALYTICS_TRACKING_ID: '{{ CW_GA_TRACKING_ID }}'
         };
     </script>
-    <script src="/govuk-frontend/all.js"></script>
-    <script nonce="{{ nonce }}">window.GOVUKFrontend.initAll()</script>
-    <script src="https://code.jquery.com/jquery-3.6.3.min.js" integrity="sha256-pvPw+upLPUjgMXY0G+8O0xUf+/Im1MZjXxxgOcBQBXU=" crossorigin="anonymous"></script>
-    <script src="/dist/js/autocomplete.min.js"></script>
-    <script src="/dist/js/bundle.js"></script>
+    <script nonce="{{ cspNonce }}" src="/govuk-frontend/all.js"></script>
+    <script nonce="{{ cspNonce }}">window.GOVUKFrontend.initAll()</script>
+    <script nonce="{{ cspNonce }}" src="https://code.jquery.com/jquery-3.6.3.min.js" integrity="sha256-pvPw+upLPUjgMXY0G+8O0xUf+/Im1MZjXxxgOcBQBXU=" crossorigin="anonymous"></script>
+    <script nonce="{{ cspNonce }}" src="/dist/js/autocomplete.min.js"></script>
+    <script nonce="{{ cspNonce }}" src="/dist/js/bundle.js"></script>
 {% endblock %}
 
 {% block footer %}

--- a/questionnaire/form-helper.js
+++ b/questionnaire/form-helper.js
@@ -75,7 +75,7 @@ function renderSection({
                 </form>
             {% endblock %}
         `,
-        {nonce: cspNonce, isAuthenticated}
+        {cspNonce, isAuthenticated}
     );
 }
 

--- a/questionnaire/routes.js
+++ b/questionnaire/routes.js
@@ -30,7 +30,7 @@ router.route('/start-or-resume').get((req, res) => {
         const html = render('start-or-resume.njk', {
             csrfToken: req.csrfToken(),
             submitButtonText: getFormSubmitButtonText('start'),
-            nonce: res.locals.nonce
+            cspNonce: res.locals.cspNonce
         });
         return res.send(html);
     } catch (err) {
@@ -55,7 +55,7 @@ router.post('/start-or-resume', (req, res) => {
         const html = render('start-or-resume.njk', {
             csrfToken: req.csrfToken(),
             submitButtonText: getFormSubmitButtonText('start'),
-            nonce: res.locals.nonce,
+            cspNonce: res.locals.cspNonce,
             error: {
                 text: 'Select what you would like to do'
             }
@@ -195,7 +195,7 @@ router
             const html = formHelper.getSectionHtml(
                 response.body,
                 req.csrfToken(),
-                res.locals.nonce,
+                res.locals.cspNonce,
                 isAuthenticated
             );
             if (formHelper.getSectionContext(sectionId) === 'confirmation') {
@@ -279,7 +279,7 @@ router
                 response.body,
                 sectionId,
                 req.csrfToken(),
-                res.locals.nonce,
+                res.locals.cspNonce,
                 isAuthenticated
             );
             return res.send(html);

--- a/test/test-fixtures/transformations/resolved html/p-applicant-british-citizen-or-eu-national.js
+++ b/test/test-fixtures/transformations/resolved html/p-applicant-british-citizen-or-eu-national.js
@@ -41,10 +41,10 @@ const html = `<!DOCTYPE html>
     <meta property="og:image" content="/assets/images/govuk-opengraph-image.png">
   </head>
   <body class="govuk-template__body ">
-    <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
+    <script nonce="somenonce">document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
 
 <!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id="></script>
+<script nonce="somenonce" async src="https://www.googletagmanager.com/gtag/js?id="></script>
     <script nonce="somenonce">
         window.dataLayer = window.dataLayer || [];
         function gtag(){
@@ -542,11 +542,11 @@ window.CICA = {
   ANALYTICS_TRACKING_ID: ''
 };
 </script>
-<script src="/govuk-frontend/all.js"></script>
+<script nonce="somenonce" src="/govuk-frontend/all.js"></script>
   <script nonce="somenonce">window.GOVUKFrontend.initAll()</script>
-  <script src="https://code.jquery.com/jquery-3.6.3.min.js "integrity="sha256-pvPw+upLPUjgMXY0G+8O0xUf+/Im1MZjXxxgOcBQBXU="crossorigin="anonymous"></script>
-  <script src="/dist/js/autocomplete.min.js"></script>
-  <script src="/dist/js/bundle.js"></script>
+  <script nonce="somenonce" src="https://code.jquery.com/jquery-3.6.3.min.js "integrity="sha256-pvPw+upLPUjgMXY0G+8O0xUf+/Im1MZjXxxgOcBQBXU="crossorigin="anonymous"></script>
+  <script nonce="somenonce" src="/dist/js/autocomplete.min.js"></script>
+  <script nonce="somenonce" src="/dist/js/bundle.js"></script>
   </body>
 </html>
 `;

--- a/test/test-fixtures/transformations/resolved html/p-some-section.js
+++ b/test/test-fixtures/transformations/resolved html/p-some-section.js
@@ -40,7 +40,7 @@ const html = `<!DOCTYPE html>
     <meta property="og:image" content="/assets/images/govuk-opengraph-image.png">
 </head>
 <body class="govuk-template__body ">
-<script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
+<script nonce="somenonce">document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
 
 
 
@@ -197,7 +197,7 @@ const html = `<!DOCTYPE html>
 
 
 
-<script src="/govuk-frontend/all.js"></script>
+<script nonce="somenonce" src="/govuk-frontend/all.js"></script>
 <script nonce="somenonce">window.GOVUKFrontend.initAll()</script>
 
 </body>


### PR DESCRIPTION
* Add `strict-dynamic`, and `unsafe-inline` csp directives which can be used in conjunction with each other
* the govuk/frontend `template.njk` now has a `cspNonce` parameter that can be optionally passed in. So this enables the removal of the specific hashes defined in `app.js` - more maintainable.
* update all reference of nonce to `cspNonce` for consistency with the above.
* Add `nonce` attribute to all script tags