### PR TITLE
Remove one login from new pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "cica-web",
-    "version": "7.1.11",
+    "version": "7.1.12",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "cica-web",
-            "version": "7.1.11",
+            "version": "7.1.12",
             "license": "MIT",
             "dependencies": {
                 "@ministryofjustice/frontend": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cica-web",
-    "version": "7.1.11",
+    "version": "7.1.12",
     "engines": {
         "npm": ">=9.5.0",
         "node": ">=18.16.1"

--- a/questionnaire/questionnaireUISchema.js
+++ b/questionnaire/questionnaireUISchema.js
@@ -1972,6 +1972,9 @@ module.exports = {
     },
     'p-applicant-under-18': {
         options: {
+            signInLink: {
+                visible: false
+            },
             outputOrder: ['applicant-under-18-info', 'q-applicant-under-18'],
             properties: {
                 'q-applicant-under-18': {
@@ -2036,6 +2039,48 @@ module.exports = {
                         }
                     }
                 }
+            }
+        }
+    },
+    'p--context-crime-ref-no': {
+        options: {
+            signInLink: {
+                visible: false
+            }
+        }
+    },
+    'p-applicant-what-do-you-want-to-do': {
+        options: {
+            signInLink: {
+                visible: false
+            }
+        }
+    },
+    'p--transition-apply-when-18': {
+        options: {
+            signInLink: {
+                visible: false
+            }
+        }
+    },
+    'p--transition-request-a-call-back': {
+        options: {
+            signInLink: {
+                visible: false
+            }
+        }
+    },
+    'p--transition-contact-us': {
+        options: {
+            signInLink: {
+                visible: false
+            }
+        }
+    },
+    'p--transition-someone-18-or-over-to-apply': {
+        options: {
+            signInLink: {
+                visible: false
             }
         }
     }


### PR DESCRIPTION
Configure new pages so that one login doesn't appear. 

Only pages after the "applicant name" page should have the One Login link on it. Any pages that are before (and including) that specific page in the journey should not have the One Login link on it.