### PR TITLE
Fix/remove incident property

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "cica-web",
-    "version": "7.4.0",
+    "version": "7.4.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "cica-web",
-            "version": "7.4.0",
+            "version": "7.4.1",
             "license": "MIT",
             "dependencies": {
                 "@ministryofjustice/frontend": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cica-web",
-    "version": "7.4.0",
+    "version": "7.4.1",
     "engines": {
         "npm": ">=9.5.0",
         "node": ">=18.16.1"

--- a/questionnaire/questionnaireUISchema.js
+++ b/questionnaire/questionnaireUISchema.js
@@ -2040,7 +2040,7 @@ module.exports = {
     },
     'p-applicant-describe-incident': {
         options: {
-            outputOrder: ['describe-incident-info', 'q-applicant-describe-incident'],
+            outputOrder: ['q-applicant-describe-incident'],
             properties: {
                 'q-applicant-describe-incident': {
                     options: {


### PR DESCRIPTION
Remove reference to the `describe-incident-info` property to prevent templates getting stuck