### PR TITLE
Capp 140 one login rate limit redirect

### DIFF
--- a/account/issuer.test.js
+++ b/account/issuer.test.js
@@ -58,3 +58,34 @@ describe('OIDC issuer', () => {
         });
     });
 });
+
+describe('GOV.UK One Login rate limiting', () => {
+    describe('temporarily_unavailable error', () => {
+        beforeEach(() => {
+            setUpCommonMocks({
+                '../account/routes': () => {
+                    const express = require('express');
+                    const router = express.Router();
+                    router.get('/rate-limit-test', (req, res, next) => {
+                        const err = new Error('temporarily_unavailable');
+                        err.error = 'temporarily_unavailable';
+                        next(err);
+                    });
+                    return router;
+                }
+            });
+        });
+
+        it('Should return a 503 status code', async () => {
+            const response = await request(app).get('/account/rate-limit-test');
+            expect(response.statusCode).toBe(503);
+        });
+
+        it('Should render the oidc-provider-unreachable template with oidc-rate-limit section', async () => {
+            const response = await request(app).get('/account/rate-limit-test');
+            expect(response.res.text).toContain(
+                'https://www.smartsurvey.co.uk/s/inpagefeedback/?page=oidc-rate-limit'
+            );
+        });
+    });
+});

--- a/app.js
+++ b/app.js
@@ -223,6 +223,14 @@ app.use((err, req, res, next) => {
         }
     }
 
+    // Handles rate limiting from GOV.UK One Login returning error=temporarily_unavailable.
+    if (err.error === 'temporarily_unavailable') {
+        return res.status(503).render('oidc-provider-unreachable.njk', {
+            backTarget: req?.session?.referrer,
+            sectionId: 'oidc-rate-limit'
+        });
+    }
+
     // Page not found, can also be as a result of session timeout
     if (err.name === 'PageNotFound') {
         // timeout handler

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "cica-web",
-    "version": "7.8.12",
+    "version": "7.8.14",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "cica-web",
-            "version": "7.8.12",
+            "version": "7.8.14",
             "license": "MIT",
             "dependencies": {
                 "@ministryofjustice/frontend": "^5.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cica-web",
-    "version": "7.8.13",
+    "version": "7.8.14",
     "engines": {
         "npm": ">=11.12.1",
         "node": ">=24.15.0"


### PR DESCRIPTION
- When One Login sends `temporarily_unavailable` error, show the service unavailable page.