### PR TITLE
Capp 154 show correct error pages

### DIFF
--- a/kube_deploy/Dev/ingress.yml
+++ b/kube_deploy/Dev/ingress.yml
@@ -6,7 +6,10 @@ metadata:
   annotations:
     external-dns.alpha.kubernetes.io/aws-weight: '100'
     external-dns.alpha.kubernetes.io/set-identifier: webapp-ingress-claim-criminal-injuries-compensation-dev-green
-    nginx.ingress.kubernetes.io/custom-http-errors: '406'
+    # 403 - WAF blocks (e.g. SQL injection) go to default backend error page
+    # 406 - Used deliberately for ModSec unknown URL blocks (rule 700020) so they
+    #        go to the default backend without interfering with the app's own 404 handling
+    nginx.ingress.kubernetes.io/custom-http-errors: '403,406'
     nginx.ingress.kubernetes.io/default-backend: default
     nginx.ingress.kubernetes.io/enable-modsecurity: 'true'
     nginx.ingress.kubernetes.io/modsecurity-transaction-id: '$request_id'

--- a/kube_deploy/Prod/ingress.yml
+++ b/kube_deploy/Prod/ingress.yml
@@ -6,7 +6,10 @@ metadata:
   annotations:
     external-dns.alpha.kubernetes.io/aws-weight: '100'
     external-dns.alpha.kubernetes.io/set-identifier: webapp-ingress-claim-criminal-injuries-compensation-prod-green
-    nginx.ingress.kubernetes.io/custom-http-errors: '406'
+    # 403 - WAF blocks (e.g. SQL injection) go to default backend error page
+    # 406 - Used deliberately for ModSec unknown URL blocks (rule 700020) so they
+    #        go to the default backend without interfering with the app's own 404 handling
+    nginx.ingress.kubernetes.io/custom-http-errors: '403,406'
     nginx.ingress.kubernetes.io/default-backend: default
     nginx.ingress.kubernetes.io/enable-modsecurity: 'true'
     nginx.ingress.kubernetes.io/modsecurity-transaction-id: '$request_id'

--- a/kube_deploy/Stag/ingress.yml
+++ b/kube_deploy/Stag/ingress.yml
@@ -6,7 +6,10 @@ metadata:
   annotations:
     external-dns.alpha.kubernetes.io/aws-weight: '100'
     external-dns.alpha.kubernetes.io/set-identifier: webapp-ingress-claim-criminal-injuries-compensation-stag-green
-    nginx.ingress.kubernetes.io/custom-http-errors: '406'
+    # 403 - WAF blocks (e.g. SQL injection) go to default backend error page
+    # 406 - Used deliberately for ModSec unknown URL blocks (rule 700020) so they
+    #        go to the default backend without interfering with the app's own 404 handling
+    nginx.ingress.kubernetes.io/custom-http-errors: '403,406'
     nginx.ingress.kubernetes.io/default-backend: default
     nginx.ingress.kubernetes.io/enable-modsecurity: 'true'
     nginx.ingress.kubernetes.io/modsecurity-transaction-id: '$request_id'

--- a/kube_deploy/Uat/ingress.yml
+++ b/kube_deploy/Uat/ingress.yml
@@ -6,7 +6,10 @@ metadata:
   annotations:
     external-dns.alpha.kubernetes.io/aws-weight: '100'
     external-dns.alpha.kubernetes.io/set-identifier: webapp-ingress-claim-criminal-injuries-compensation-uat-green
-    nginx.ingress.kubernetes.io/custom-http-errors: '406'
+    # 403 - WAF blocks (e.g. SQL injection) go to default backend error page
+    # 406 - Used deliberately for ModSec unknown URL blocks (rule 700020) so they
+    #        go to the default backend without interfering with the app's own 404 handling
+    nginx.ingress.kubernetes.io/custom-http-errors: '403,406'
     nginx.ingress.kubernetes.io/default-backend: default
     nginx.ingress.kubernetes.io/enable-modsecurity: 'true'
     nginx.ingress.kubernetes.io/modsecurity-transaction-id: '$request_id'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "cica-web",
-    "version": "7.8.14",
+    "version": "7.8.15",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "cica-web",
-            "version": "7.8.14",
+            "version": "7.8.15",
             "license": "MIT",
             "dependencies": {
                 "@ministryofjustice/frontend": "^5.1.5",
@@ -361,18 +361,6 @@
             "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
             "dev": true,
             "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-hoist-variables": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
-            "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
-            "dev": true,
-            "dependencies": {
-                "@babel/types": "^7.22.5"
-            },
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -1302,15 +1290,16 @@
             }
         },
         "node_modules/@babel/plugin-transform-modules-systemjs": {
-            "version": "7.23.9",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.23.9.tgz",
-            "integrity": "sha512-KDlPRM6sLo4o1FkiSlXoAa8edLXFsKKIda779fbLrvmeuc3itnjCtaO6RrtoaANsIJANj+Vk1zqbZIMhkCAHVw==",
+            "version": "7.29.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz",
+            "integrity": "sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@babel/helper-hoist-variables": "^7.22.5",
-                "@babel/helper-module-transforms": "^7.23.3",
-                "@babel/helper-plugin-utils": "^7.22.5",
-                "@babel/helper-validator-identifier": "^7.22.20"
+                "@babel/helper-module-transforms": "^7.28.6",
+                "@babel/helper-plugin-utils": "^7.28.6",
+                "@babel/helper-validator-identifier": "^7.28.5",
+                "@babel/traverse": "^7.29.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -6628,9 +6617,9 @@
             "dev": true
         },
         "node_modules/fast-uri": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-            "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+            "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
             "dev": true,
             "funding": [
                 {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cica-web",
-    "version": "7.8.14",
+    "version": "7.8.15",
     "engines": {
         "npm": ">=11.12.1",
         "node": ">=24.15.0"


### PR DESCRIPTION
- 403 - WAF blocks (e.g. SQL injection) go to default backend error page
- 406 - Used deliberately for ModSec unknown URL blocks (rule 700020) so they go to the default backend without interfering with the app's own 404 handling